### PR TITLE
Added an option to enable trim setup in cryptsetup

### DIFF
--- a/src/ugrd/crypto/cryptsetup.py
+++ b/src/ugrd/crypto/cryptsetup.py
@@ -148,6 +148,9 @@ def open_crypt_device(self, name: str, parameters: dict) -> list[str]:
         out += [f"    echo 'Using header file: {header_file}'"]
         cryptsetup_command += f' --header {header_file}'
 
+    if self['cryptsetup_trim']:
+        cryptsetup_command += ' --allow-discards'
+
     # Add the variable for the source device and mapped name
     cryptsetup_command += f' $CRYPTSETUP_SOURCE_{name} {name}'
     out += [cryptsetup_command]

--- a/src/ugrd/crypto/cryptsetup.toml
+++ b/src/ugrd/crypto/cryptsetup.toml
@@ -28,3 +28,4 @@ cryptsetup_key_type = "str"  # The default key type to use for unlocking devices
 cryptsetup_key_types = "dict"  # Dict containing key types and their associated mount commands
 cryptsetup_retries = "int"  # Number of times to retry unlocking a device
 cryptsetup_autoretry = "bool"  # Whether to automatically retry unlocking devices
+cryptsetup_trim = "bool"


### PR DESCRIPTION
Currently ugrd doesn't support enabling trim support for ssds, this enables that.

I have tested this on my own system and have inspected init_funcs.sh with the option enabled and not to ensure that it functions as expected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to enable or disable discards (trim) when opening encrypted devices, enhancing performance and device management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->