### PR TITLE
simplify default mounts/mountpoints

### DIFF
--- a/examples/example.toml
+++ b/examples/example.toml
@@ -1,5 +1,5 @@
 # This config will decrypt the LUKS volume with uuid "fdf442da-0574-4531-98c7-55227a041f1d", mapping it to "/dev/mapper/root"
-# It will attempt to mount the btrfs volume with label "rootfs" to /mnt/root
+# It will attempt to mount the btrfs volume with label "rootfs" to /target_rootfs
 # It will pull all current kernel modules from lspci -k results
 # It will try to process the cmdline and mount the rootfs based on the root= parameter
 

--- a/readme.md
+++ b/readme.md
@@ -354,7 +354,7 @@ Similarly `ugrd.kmod.novideo` `nonetwork`, and `nosound` exist to ignore video, 
 
 `mounts`: A dictionary containing entries for mounts, with their associated config.
 
-`mounts.root` is predefined to have a destination of `/mnt/root` and defines the root filesystem mount, used by `switch_root`.
+`mounts.root` is predefined to have a destination of `/target_rootfs` and defines the root filesystem mount, used by `switch_root`.
 
 Each mount has the following available parameters:
 
@@ -413,7 +413,7 @@ Importing this module will run `btrfs device scan` and pull btrfs modules.
 * `subvol_selector` (false) The root subvolume will be selected at runtime based on existing subvolumes. Overridden by `root_subvol`.
 * `autodetect_root_subvol` (true) Autodetect the root subvolume, unless `root_subvol` or `subvol_selector` is set. Depends on `hostonly`.
 * `root_subvol` - Set the desired root subvolume.
-* `_base_mount_path` (/mnt/root_base) Sets where the subvolume selector mounts the base filesytem to scan for subvolumes.
+* `_base_mount_path` (/root_base) Sets where the subvolume selector mounts the base filesytem to scan for subvolumes.
 
 ### Cryptographic modules
 

--- a/src/ugrd/fs/btrfs.toml
+++ b/src/ugrd/fs/btrfs.toml
@@ -1,7 +1,7 @@
 binaries = [ "btrfs" ]
 kmod_init = "btrfs"
 
-_base_mount_path = "/mnt/root_base"
+_base_mount_path = "/root_base"
 subvol_selector = false
 autodetect_root_subvol = true
 

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -61,7 +61,7 @@ _blkid_info = "dict"  # The blkid information
 # Define the base of the root mount
 [mounts.root]
 options = ['ro']
-destination = "/mnt/root"
+destination = "/target_rootfs"
 
 # Define the default mounts
 # The format is mounts.mount where the mount is the name of the mount


### PR DESCRIPTION
Make most mounts mount under dirs under the root mountpoint, helps keep things simpler, and makes it less likely that a user can do something like define a mount at /mnt and mess things up at runtime.

Moved the btrfs subvol selector mountpoint to the root as well.