### PR TITLE
keymap: Ignore utf-8 decoding errors

### DIFF
--- a/src/ugrd/base/keymap.py
+++ b/src/ugrd/base/keymap.py
@@ -57,7 +57,7 @@ def _add_keymap_file(self, keymap_file: str) -> None:
         self["dependencies"] = keymap_file
         keymap_data = open(keymap_file, "rb").read()
 
-    keymap_data = keymap_data.decode()
+    keymap_data = keymap_data.decode(errors="ignore")
 
     for line in keymap_data.splitlines():
         if line.startswith("include"):


### PR DESCRIPTION
The keymap module scans keymap files for include directives to identify further keymap files to be included. Keymap files, however, have different encodings. The default "utf-8" of decode() produces errors when an invalid character is found, say, when a ISO-8859 character is found.

This is, for instance, the case for keymaps/i386/include/compose.inc in the upstream repository, causing ugrd to fail. Greetings to Bernhard Rosenkränzer.

Add an option to decode() to ignore errors, which should be safe assuming that the include directives are not affected. A more involved solution would be to use the 'magic' package for the 'file' utility.