### PR TITLE
Improve testing

### DIFF
--- a/src/ugrd/base/test.py
+++ b/src/ugrd/base/test.py
@@ -1,8 +1,8 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from zenlib.util import unset
 
-COPY_CONFIG = ["mounts", "tmpdir", "clean", "test_image_size", "test_flag", "cryptsetup"]
+COPY_CONFIG = ["mounts", "out_dir", "tmpdir", "clean", "test_image_size", "test_flag", "cryptsetup"]
 
 
 @unset("test_kernel")

--- a/tests/test_output_paths.py
+++ b/tests/test_output_paths.py
@@ -35,6 +35,25 @@ class TestOutFile(TestCase):
         generator.build()
         self.assertTrue(out_path.exists())
         out_path.unlink()
+        test_image = Path(generator["test_rootfs_name"])
+        self.assertTrue(test_image.exists())
+        test_image.unlink()
+
+    def test_TMPDIR(self):
+        """Tests that the TMPDIR environment variable is respected"""
+        from tempfile import TemporaryDirectory
+        from os import environ
+        try:
+            with TemporaryDirectory() as tmpdir:
+                environ["TMPDIR"] = tmpdir
+                generator = InitramfsGenerator(logger=self.logger, config="tests/fullauto.toml")
+                generator.build()
+                self.assertTrue(Path(tmpdir).exists())
+                self.assertTrue((Path(tmpdir) / 'initramfs_test' / generator.out_file).exists())
+        except Exception as e:
+            self.fail(f"Exception: {e}")
+        finally:
+            environ.pop("TMPDIR")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
add tests for TMPDIR usage at build time
improve relative out file test to not leave test files in the dir where it is run