### PR TITLE
Debug select editor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,7 @@ This module contains debug programs such as `cp`, `mv`, `rm`, `grep`, `dmesg`, `
 Setting `start_shell` to `true` will start a bash shell in `init_debug`.
 
 Use `editor` to manually specify the editor binary, otherwise it is autodetected from the `EDITOR` environment variable
+> If `validation` is enabled the editor binary is checked against a list of common editors, use `no_validate_editor` to skip this check if needed
 
 ### Kernel modules
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,9 +144,11 @@ Defines /dev/ttyS1 as a `vt100` terminal with a `115200` baud rate.
 
 #### base.debug
 
-This module contains debug programs such as `cp`, `mv`, `rm`, `grep`, `dmesg`, `find`, and `nano`,
+This module contains debug programs such as `cp`, `mv`, `rm`, `grep`, `dmesg`, `find`, and an editor,
 
 Setting `start_shell` to `true` will start a bash shell in `init_debug`.
+
+Use `editor` to manually specify the editor binary, otherwise it is autodetected from the `EDITOR` environment variable
 
 ### Kernel modules
 

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -2,9 +2,9 @@ __author__ = "desultory"
 __version__ = "1.3.1"
 
 from zenlib.util import contains
-from ugrd import AutodetectError
+from ugrd import AutodetectError, ValidationError
 
-EXPECTED_EDITORS = { 'nano', 'vim', 'vi', 'emacs' }
+EXPECTED_EDITORS = { "nano", "vim", "vi", "emacs" }
 
 def _detect_editor(self) -> None:
     from os import environ
@@ -17,11 +17,15 @@ def _detect_editor(self) -> None:
     try:
         self["binaries"] = editor
     except AutodetectError:
-        raise AutodetectError(f"Failed to locate editor binary '{editor}' in PATH")
+        raise AutodetectError(f"Failed to locate editor binary: '{editor}'")
 
     # Send a warning if the editor it's a common one, but still use it if it exists
     if editor not in EXPECTED_EDITORS:
-       self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
+       if self.get("validate") and not self.get("no_validate_editor"):
+           raise ValidationError(f"Use of unrecognised editor {editor} with validation enabled")
+       else:
+           self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
+
 
 
 def start_shell(self) -> str:

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -3,6 +3,26 @@ __version__ = "1.3.1"
 
 from zenlib.util import contains
 
+def _determine_editor(self) -> None:
+    # expected values, others raise a warning but still work fine
+    expected_editors = [ 'vim', 'nano', 'emacs' ]
+    
+    from os import environ
+    editor = self.get("editor") or environ.get("EDITOR") or "nano"
+    
+    # setting value will automatically call the hook to validate the path
+    # reraising to tell the user it's the editor config to help narrow down the issue
+    try:
+        self["binaries"] = editor
+    except (ValueError, RuntimeError):
+        raise ValueError(f"Editor binary '{editor}' could not be located in PATH")
+    
+    # Report which binary gets used (send a warning if it's not recognised
+    self.logger.info(f"[debug] Using '{editor}' as editor.")
+    
+    if editor not in expected_editors:
+       self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
+
 
 def start_shell(self) -> str:
     """Start a bash shell at the start of the initramfs."""

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -1,7 +1,7 @@
 __author__ = "desultory"
 __version__ = "1.3.1"
 
-from zenlib.util import contains
+from zenlib.util import contains, colorize
 from ugrd import AutodetectError, ValidationError
 
 EXPECTED_EDITORS = { "nano", "vim", "vi", "emacs" }
@@ -10,19 +10,19 @@ def _detect_editor(self) -> None:
     from os import environ
     editor = self.get("editor") or environ.get("EDITOR") or "nano"
     
-    self.logger.info(f"[debug] Using '{editor}' as editor.")
+    self.logger.info("[debug] Using editor: %s" % colorize(editor, "cyan"))
     
     # setting value will automatically call the hook to validate the path
     # reraising to tell the user it's the editor config to help narrow down the issue
     try:
         self["binaries"] = editor
     except AutodetectError:
-        raise AutodetectError(f"Failed to locate editor binary: '{editor}'")
+        raise AutodetectError("Failed to locate editor binary: %s" % colorize(editor, "cyan"))
 
     # Send a warning if the editor it's a common one, but still use it if it exists
     if editor not in EXPECTED_EDITORS:
        if self.get("validate") and not self.get("no_validate_editor"):
-           raise ValidationError(f"Use of unrecognised editor {editor} with validation enabled")
+           raise ValidationError("Use of unrecognised editor %s with validation enabled" % colorize(editor, "cyan"))
        else:
            self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
 

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -6,7 +6,7 @@ from ugrd import AutodetectError, ValidationError
 
 EXPECTED_EDITORS = { "nano", "vim", "vi", "emacs" }
 
-def _detect_editor(self) -> None:
+def detect_editor(self) -> None:
     from os import environ
     editor = self.get("editor") or environ.get("EDITOR") or "nano"
     
@@ -24,7 +24,7 @@ def _detect_editor(self) -> None:
        if self.get("validate") and not self.get("no_validate_editor"):
            raise ValidationError("Use of unrecognised editor %s with validation enabled" % colorize(editor, "cyan"))
        else:
-           self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
+           self.logger.warning("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
 
 
 

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -2,25 +2,25 @@ __author__ = "desultory"
 __version__ = "1.3.1"
 
 from zenlib.util import contains
+from ugrd import AutodetectError
 
-def _determine_editor(self) -> None:
-    # expected values, others raise a warning but still work fine
-    expected_editors = [ 'vim', 'nano', 'emacs' ]
-    
+EXPECTED_EDITORS = { 'nano', 'vim', 'vi', 'emacs' }
+
+def _detect_editor(self) -> None:
     from os import environ
     editor = self.get("editor") or environ.get("EDITOR") or "nano"
+    
+    self.logger.info(f"[debug] Using '{editor}' as editor.")
     
     # setting value will automatically call the hook to validate the path
     # reraising to tell the user it's the editor config to help narrow down the issue
     try:
         self["binaries"] = editor
-    except (ValueError, RuntimeError):
-        raise ValueError(f"Editor binary '{editor}' could not be located in PATH")
-    
-    # Report which binary gets used (send a warning if it's not recognised
-    self.logger.info(f"[debug] Using '{editor}' as editor.")
-    
-    if editor not in expected_editors:
+    except AutodetectError:
+        raise AutodetectError(f"Failed to locate editor binary '{editor}' in PATH")
+
+    # Send a warning if the editor it's a common one, but still use it if it exists
+    if editor not in EXPECTED_EDITORS:
        self.logger.warn("Editor binary not recognised, can be overridden with 'editor' in config or EDITOR in environment if incorrect, otherwise can be disregarded.")
 
 

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -7,7 +7,7 @@ binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
 start_shell = true
 
 [imports.build_enum]
-"ugrd.base.debug" = [ "_detect_editor" ]
+"ugrd.base.debug" = [ "detect_editor" ]
 
 [imports.init_pre]
 "ugrd.base.debug" = [ "enable_debug" ]

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -5,7 +5,6 @@ binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
 # 3. fallback to 'nano'
 
 start_shell = true
-no_validate_editor = false
 
 [imports.build_enum]
 "ugrd.base.debug" = [ "_detect_editor" ]

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -7,7 +7,7 @@ binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
 start_shell = true
 
 [imports.build_enum]
-"ugrd.base.debug" = [ "_determine_editor" ]
+"ugrd.base.debug" = [ "_detect_editor" ]
 
 [imports.init_pre]
 "ugrd.base.debug" = [ "enable_debug" ]

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -5,6 +5,7 @@ binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
 # 3. fallback to 'nano'
 
 start_shell = true
+no_validate_editor = false
 
 [imports.build_enum]
 "ugrd.base.debug" = [ "_detect_editor" ]
@@ -18,3 +19,4 @@ start_shell = true
 [custom_parameters]
 start_shell = "bool"  # Start a shell after init_early, before init_pre. Can be enabled by the debug cmdline option.
 editor = "str"	# override editor variable
+no_validate_editor = "bool" # will skip validation of the editor binary, when validation is in use. Otherwise does nothing. 

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -1,6 +1,13 @@
-binaries = ['cp', 'mv', 'rm', 'nano', 'find', 'grep', 'dmesg', 'chmod', 'touch']
+binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
+# EDITOR is determined at build time using (in order):
+# 1. editor config parameter
+# 2. $EDITOR environment variable
+# 3. fallback to 'nano'
 
 start_shell = true
+
+[imports.build_enum]
+"ugrd.base.debug" = [ "_determine_editor" ]
 
 [imports.init_pre]
 "ugrd.base.debug" = [ "enable_debug" ]
@@ -10,3 +17,4 @@ start_shell = true
 
 [custom_parameters]
 start_shell = "bool"  # Start a shell after init_early, before init_pre. Can be enabled by the debug cmdline option.
+editor = "str"	# override editor variable

--- a/src/ugrd/initramfs_dict.py
+++ b/src/ugrd/initramfs_dict.py
@@ -296,7 +296,7 @@ class InitramfsConfigDict(UserDict):
     def validate(self) -> None:
         """Validate config, checks that all values are processed, sets validated flag."""
         if self["_processing"]:
-            self.logger.critical("Unprocessed config values: %s" % colorize(", ".join(list(self["_processing"].keys()), "red", bold=True)))
+            self.logger.critical("Unprocessed config values: %s" % colorize(", ".join(list(self["_processing"].keys())), "red", bold=True))
         self["validated"] = True
 
     def __str__(self) -> str:


### PR DESCRIPTION
At the moment the debug module has a hard-coded dependency on `nano` as the editor.
This adds code to detect the system/preferred editor based on the `EDITOR` environment variable, and provides the `editor` parameter in config to override it.

In case the user is running from a terminal that (for whatever reason) has set the `EDITOR` variable to something unusual, it will also throw a warning when they're not in a predefined list of regular values.

(also found a missing bracket in a join function in `initramfs_dict.py` that caused  a runtime error when testing, so I just added that in too)