### PR TITLE
Fixes to the validation bug and formatting with the editor select code

### DIFF
--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -1,4 +1,5 @@
 binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
+dependencies = [ "/usr/share/terminfo/l/linux" ] # required by most editors
 # EDITOR is determined at build time using (in order):
 # 1. editor config parameter
 # 2. $EDITOR environment variable
@@ -17,5 +18,5 @@ start_shell = true
 
 [custom_parameters]
 start_shell = "bool"  # Start a shell after init_early, before init_pre. Can be enabled by the debug cmdline option.
-editor = "str"	# override editor variable
-no_validate_editor = "bool" # will skip validation of the editor binary, when validation is in use. Otherwise does nothing. 
+editor = "str"  # override editor variable
+no_validate_editor = "bool"  # will skip validation of the editor binary, when validation is in use. Otherwise does nothing.


### PR DESCRIPTION
Fixed up that issue with the validation by getting it to check the basename using pathlib, in case the user specifies the full path to the editor.

I also used ALEFix to clean up the formatting, so all the indentation stuff should be alright now (hopefully lol)

Did more testing with debug mode, I found that without include `/usr/share/terminfo/l/linux` as a dependency `nano` will refuse to start. `vim`/`vi` will still open, but will complain about it. I added it as a dependency for the module, since it's needed for pretty much any editor and having it available makes shells happier too.

Had to remove `emacs` from the EXPECTED_EDITORS list, I wanted to include it because it's a common editor, however once all the libraries are pulled in it adds quite a bit to the image size. In addition `emacs` expects a large number of lisp scripts and other dependencies from `/usr/share`, and just ends up being unreasonably large.

There's no reason why it can't be included by choice, but I'm not sure about making it generally accepted one. `nano`/`vim`/`vi` will at least work without startup scripts, they complain a bit but can still be used. I believe most of the other (many) small terminal editors should be fine too, but I haven't tested those so wouldn't want to add blindly.