### PR TITLE
refactor cryptsetup unlocks

### DIFF
--- a/src/ugrd/crypto/cryptsetup.toml
+++ b/src/ugrd/crypto/cryptsetup.toml
@@ -21,7 +21,7 @@ cryptsetup_header_validation = true
 "ugrd.crypto.cryptsetup" = [ "crypt_init" ]
 
 [imports.functions]
-"ugrd.crypto.cryptsetup" = [ "get_crypt_dev" ]
+"ugrd.crypto.cryptsetup" = [ "get_crypt_dev", "open_crypt_dev" ]
 
 [custom_parameters]
 cryptsetup_key_type = "str"  # The default key type to use for unlocking devices


### PR DESCRIPTION
this should be better flow control, and includes the header file info in the initramfs for usage.

Counts key unlock commands as a failure to not attempt an empty key file.

If multiple luks devices are used, checks them individually for better failure recovery.

The open_crypt_dev function should be easier to use in recovery cases.