### PR TITLE
52-ugrd.install: install to staging area

### DIFF
--- a/hooks/installkernel/52-ugrd.install
+++ b/hooks/installkernel/52-ugrd.install
@@ -4,7 +4,7 @@
 
 ver=${1}
 img=${2}
-initrd=$(dirname "${img}")/initrd
+initrd=${INSTALLKERNEL_STAGING_AREA}/initrd
 
 # familiar helpers, we intentionally don't use Gentoo functions.sh
 die() {


### PR DESCRIPTION
This changes the installkernel hook to use the staging area that will be introduced in the next version.