### PR TITLE
V2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,15 @@ Variables should generally be colored using the following scheme:
 
 bools to disable validation should be named in the format: `no_validate_<attr>`.
 
-> bools are initialized to `False` so does not need to be set unless defaulting to `True`
+> bools are initialized to `False` so do not need to be set unless defaulting to `True`
 
 ### Function names
 
 * Variable processing functions MUST be named in the format: `_process_<attr>`.
 * Functions which are not used outside of the module should be prefixed with an underscore.
 * Autodetection functions should be named in the format: `autodetect_<attr>`.
+* Enumeration functions should be named `get_<thing>`. such as `get_blkid_info`.
 * Validation functions should be named in the format: `validate_<attr>`.
+* Check functions should be named in the format: `check_<attr>`.
 * Functions which move files into the build dir or image should be named `deploy_<thing>`.
 * Functions which update the exports should be named `export_<thing>`. such as `export_mount_info`.
-* Enumeration functions should be named `get_<thing>`. such as `get_blkid_info`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ Modules write to a shared config dict that is accessible by other modules.
 * `clean` (true) forces the build dir to be cleaned on each run.
 * `old_count` (1) Sets the number of old file to keep when running the `_rotate_old` function.
 * `binaries` - A list used to define programs to be pulled into the initrams. `which` is used to find the path of added entries, and `lddtree` is used to resolve dependendies.
+* `libraries` - A list of libaries searched for and added to the initramfs, by name.
 * `paths` - A list of directores to create in the `build_dir`. They do not need a leading `/`.
 * `shell` (/bin/sh) Sets the shell to be used in the init script.
 

--- a/docs/dev_manual.md
+++ b/docs/dev_manual.md
@@ -18,6 +18,16 @@ UGRD allows python functions to be imported from modules using the `imports` dic
 
 `imports` entries have a key which is the name of the hook to import into, and a value which is a dict of module names and lists of functions to import.
 
+## Import order
+
+Imports can be ordered using the `import_order` dict.
+
+The key name defined in `before` will be run before values in the `after` list (value) by name.
+
+Likewise, keys in the `after` list will be run after the key in the `before` value.
+
+> `after` targets are moved before the key when creating the hook order, not literally after.
+
 ### Import types
 
 There are two primary categories for imports, `build` and `init`. Build imports are used to mutate the config and build the base structure of the initramfs, while init imports are used to generate the init scripts.

--- a/docs/dev_manual.md
+++ b/docs/dev_manual.md
@@ -84,12 +84,9 @@ Build imports are used to mutate config and build the base structure of the init
 By default, the following init hooks are available:
 * `init_pre` - Where the base initramfs environment is set up; basic mounts are initialized and the kernel cmdline is read.
 * `init_debug` - Where a shell is started if `start_shell` is enabled in the debug module.
-* `init_early` - Where early actions such as checking for device paths, mounting the fstab take place.
 * `init_main` - Most important initramfs activities should take place here.
 * `init_late` - Space for late initramfs actions, such as activating LVM volumes.
-* `init_premount` - Where filesystem related commands such as `btrfs device scan` can run.
 * `init_mount` - Where the root filesystem mount takes place
-* `init_mount_late` - Where late mount actions such as mounting paths under the root filesystem can take place.
 * `init_cleanup` - Currently unused, where cleanup before `switch_root` should take place.
 * `init_final` - Where `switch_root` is executed.
 

--- a/docs/dev_manual.md
+++ b/docs/dev_manual.md
@@ -204,3 +204,12 @@ This module is loaded in the imports section of the `base.yaml` file:
 "ugrd.fs.mounts" = [ "_process_mounts_multi" ]
 ```
 
+## Provides/needs
+
+Modules can provide/need a certain "tag" to be set by other modules.
+
+If a module has a `provides` string or list of strings, those will be added to config["provided"].
+When a module has a `needs` string or list of strings, those will be checked against config["provided"].
+
+Needed tags are checked after module imports and before any module config. Provided tags are set upon successful module import.
+

--- a/docs/dev_manual.md
+++ b/docs/dev_manual.md
@@ -85,9 +85,7 @@ By default, the following init hooks are available:
 * `init_pre` - Where the base initramfs environment is set up; basic mounts are initialized and the kernel cmdline is read.
 * `init_debug` - Where a shell is started if `start_shell` is enabled in the debug module.
 * `init_main` - Most important initramfs activities should take place here.
-* `init_late` - Space for late initramfs actions, such as activating LVM volumes.
 * `init_mount` - Where the root filesystem mount takes place
-* `init_cleanup` - Currently unused, where cleanup before `switch_root` should take place.
 * `init_final` - Where `switch_root` is executed.
 
 > These hooks are defined under the `init_types` list in the `InitramfsGenerator` object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ugrd"
-version = "1.31.2"
-
+version = "2.0.0"
 authors = [
   { name="Desultory", email="dev@pyl.onl" },
 ]

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -2,6 +2,7 @@ __author__ = "desultory"
 __version__ = "6.4.0"
 
 from pathlib import Path
+from shutil import which
 
 from ugrd import AutodetectError, ValidationError
 from zenlib.util import colorize, contains, unset
@@ -36,8 +37,6 @@ def _process_autodetect_init(self, state) -> None:
 
 def _get_shell_path(self, shell_name) -> Path:
     """Gets the real path to the shell binary."""
-    from shutil import which
-
     if shell := which(shell_name):
         return Path(shell).resolve()
     else:
@@ -47,8 +46,6 @@ def _get_shell_path(self, shell_name) -> Path:
 @contains("autodetect_init", log_level=30)
 def autodetect_init(self) -> None:
     """Autodetects the init_target."""
-    from shutil import which
-
     if init := which("init"):
         self.logger.info("Detected init at: %s", colorize(init, "cyan", bright=True))
         self["init_target"] = init

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.0"
+__version__ = "6.6.1"
 
 from pathlib import Path
 from shutil import which
@@ -31,11 +31,6 @@ def _process_loglevel(self, loglevel: int) -> None:
     self["exports"]["loglevel"] = loglevel
 
 
-@unset("init_target", "init_target is already set, skipping autodetection.", log_level=30)
-def _process_autodetect_init(self, state) -> None:
-    self.data["autodetect_init"] = state
-
-
 def _get_shell_path(self, shell_name) -> Path:
     """Gets the real path to the shell binary."""
     if shell := which(shell_name):
@@ -45,6 +40,7 @@ def _get_shell_path(self, shell_name) -> Path:
 
 
 @contains("autodetect_init", log_level=30)
+@unset("init_target", "init_target is already set, skipping autodetection.", log_level=30)
 def autodetect_init(self) -> None:
     """Autodetects the init_target."""
     if init := which("init"):

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -96,24 +96,34 @@ def set_loglevel(self) -> str:
     return "readvar loglevel > /proc/sys/kernel/printk"
 
 
-@contains("init_target", "init_target must be set.", raise_exception=True)
 def do_switch_root(self) -> str:
     """Should be the final statement, switches root.
+    Ensures it is PID 1, and that the init_target exists.
+
     Checks if the switch_root target is mounted, and that it contains an init.
+
+    If an init is not set, it will try to autodetect it.
+    If it fails to find an init, rd_fail is called.
+
     If not, it restarts UGRD.
     """
     from importlib.metadata import version
 
-    return f"""
+    return fr"""
     if [ $$ -ne 1 ] ; then
         eerror "Cannot switch_root from PID: $$, exiting."
         exit 1
     fi
-    init_target=$(readvar init) || rd_fail "init_target not set."  # should be set, if unset, checks fail
-    einfo "Checking root mount: $(readvar SWITCH_ROOT_TARGET)"
     if ! grep -q " $(readvar SWITCH_ROOT_TARGET) " /proc/mounts ; then
         rd_fail "Root not found at: $(readvar SWITCH_ROOT_TARGET)"
-    elif [ ! -e "$(readvar SWITCH_ROOT_TARGET)${{init_target}}" ] ; then
+    fi
+    if [ -z "$(readvar init)" ]; then
+        einfo "Init is no set, running autodetection."
+        _find_init || rd_fail "Unable to find init."
+    fi
+    init_target=$(readvar init)
+    einfo "Checking root mount: $(readvar SWITCH_ROOT_TARGET)"
+    if [ ! -e "$(readvar SWITCH_ROOT_TARGET)${{init_target}}" ] ; then
         ewarn "$init_target not found at: $(readvar SWITCH_ROOT_TARGET)"
         einfo "Target root contents:\n$(ls -l "$(readvar SWITCH_ROOT_TARGET)")"
         if _find_init ; then  # This redefines the var, so readvar is used instead of $init_target

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -211,7 +211,7 @@ def readvar(self) -> str:
     The second arg can be a default value.
     If no default is supplied, and the variable is not found, it returns an empty string.
     """
-    return 'cat "/run/vars/${1}" 2>/dev/null || echo "${2}"'
+    return 'cat "/run/vars/${1}" 2>/dev/null || printf "%s" "${2}"'
 
 
 def check_var(self) -> str:

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.4"
+__version__ = "6.6.5"
 
 from pathlib import Path
 from shutil import which
@@ -114,9 +114,7 @@ def do_switch_root(self) -> str:
 
     If not, it restarts UGRD.
     """
-    from importlib.metadata import version
-
-    return fr"""
+    return r"""
     if [ $$ -ne 1 ] ; then
         eerror "Cannot switch_root from PID: $$, exiting."
         exit 1
@@ -130,18 +128,18 @@ def do_switch_root(self) -> str:
     fi
     init_target=$(readvar init)
     einfo "Checking root mount: $(readvar SWITCH_ROOT_TARGET)"
-    if [ ! -e "$(readvar SWITCH_ROOT_TARGET)${{init_target}}" ] ; then
+    if [ ! -e "$(readvar SWITCH_ROOT_TARGET)${init_target}" ] ; then
         ewarn "$init_target not found at: $(readvar SWITCH_ROOT_TARGET)"
         einfo "Target root contents:\n$(ls -l "$(readvar SWITCH_ROOT_TARGET)")"
         if _find_init ; then  # This redefines the var, so readvar is used instead of $init_target
             einfo "Switching root to: $(readvar SWITCH_ROOT_TARGET) $(readvar init)"
-            klog "[UGRD {version("ugrd")}] Running init: $(readvar init)"
+            klog "[UGRD $(readvar VERSION)] Running init: $(readvar init)"
             exec switch_root "$(readvar SWITCH_ROOT_TARGET)" "$(readvar init)"
         fi
         rd_fail "Unable to find init."
     else
         einfo "Switching root to: $(readvar SWITCH_ROOT_TARGET) $init_target"
-        klog "[UGRD {version("ugrd")}] Running init: $init_target"
+        klog "[UGRD $(readvar VERSION)] Running init: $init_target"
         exec switch_root "$(readvar SWITCH_ROOT_TARGET)" "$init_target"
     fi
     """

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.5.0"
+__version__ = "6.6.0"
 
 from pathlib import Path
 from shutil import which
@@ -12,13 +12,14 @@ from zenlib.util import colorize, contains, unset
 def _validate_init_target(self) -> None:
     if not self["init_target"].exists():
         raise ValidationError("init_target not found at: %s" % self["init_target"])
-    if "systemd" in str(self["init_target"]) and "ugrd.fs.fakeudev" not in self["modules"]:
-        self.logger.warning("'ugrd.fs.fakeudev' may be required if systemd mounts stall on boot.")
 
 
 def _process_init_target(self, target: Path) -> None:
     if not isinstance(target, Path):
         target = Path(target).resolve()
+    if "systemd" in str(target) and "ugrd.fs.fakeudev" not in self["modules"]:
+        self.logger.warning("[systemd] Auto-enabling 'ugrd.fs.fakeudev'. This module is experimental.")
+        self["modules"] = "ugrd.fs.fakeudev"
     self.data["init_target"] = target
     self["exports"]["init"] = self["init_target"]
     _validate_init_target(self)

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.4.0"
+__version__ = "6.5.0"
 
 from pathlib import Path
 from shutil import which
@@ -60,6 +60,13 @@ def set_shebang(self) -> None:
     """
     self["shebang"] = f"#!/bin/sh {self['shebang_args']}"
     self.logger.info("Setting shebang to: %s", colorize(self["shebang"], "cyan", bright=True))
+
+
+def set_init_final_order(self) -> None:
+    """Adds a "before" do_switch_root order to everything in the init_final hook, excep do_switch_root."""
+    for hook in self["imports"]["init_final"]:
+        if hook.__name__ != "do_switch_root":
+            self["import_order"] = {"before": {hook.__name__: "do_switch_root"}}
 
 
 def export_switch_root_target(self) -> None:

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.3"
+__version__ = "6.6.4"
 
 from pathlib import Path
 from shutil import which
@@ -197,21 +197,21 @@ def rd_fail(self) -> list[str]:
 
 
 def setvar(self) -> str:
-    """Returns a shell function that sets a variable in /run/vars/{name}."""
+    """Returns a shell function that sets a variable in /run/ugrd/{name}."""
     return """
     if check_var debug; then
         edebug "Setting $1 to $2"
     fi
-    printf "%s" "$2" > "/run/vars/${1}"
+    printf "%s" "$2" > "/run/ugrd/${1}"
     """
 
 
 def readvar(self) -> str:
-    """Returns a shell function that reads a variable from /run/vars/{name}.
+    """Returns a shell function that reads a variable from /run/ugrd/{name}.
     The second arg can be a default value.
     If no default is supplied, and the variable is not found, it returns an empty string.
     """
-    return 'cat "/run/vars/${1}" 2>/dev/null || printf "%s" "${2}"'
+    return 'cat "/run/ugrd/${1}" 2>/dev/null || printf "%s" "${2}"'
 
 
 def check_var(self) -> str:

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -8,8 +8,9 @@ from ugrd import AutodetectError, ValidationError
 from zenlib.util import colorize, contains, unset
 
 
-@contains("hostonly")
-def _validate_init_target(self) -> None:
+@contains("validate")
+@contains("hostonly", "Skipping init validation, as hostonly is not set", log_level=30)
+def check_init_target(self) -> None:
     if not self["init_target"].exists():
         raise ValidationError("init_target not found at: %s" % self["init_target"])
 
@@ -22,7 +23,6 @@ def _process_init_target(self, target: Path) -> None:
         self["modules"] = "ugrd.fs.fakeudev"
     self.data["init_target"] = target
     self["exports"]["init"] = self["init_target"]
-    _validate_init_target(self)
 
 
 def _process_loglevel(self, loglevel: int) -> None:
@@ -39,6 +39,7 @@ def _get_shell_path(self, shell_name) -> Path:
         raise AutodetectError(f"Shell '{shell_name}' not found.")
 
 
+@contains("hostonly", "Skipping init_target autodetection, hostonly is not set.", log_level=30)
 @contains("autodetect_init", log_level=30)
 @unset("init_target", "init_target is already set, skipping autodetection.", log_level=30)
 def autodetect_init(self) -> None:

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.1"
+__version__ = "6.6.2"
 
 from pathlib import Path
 from shutil import which
@@ -94,6 +94,13 @@ def _find_init(self) -> str:
 def set_loglevel(self) -> str:
     """Returns shell lines to set the log level."""
     return "readvar loglevel > /proc/sys/kernel/printk"
+
+
+@contains("validate", "Skipping switch_root validation, as validation is disabled.", log_level=30)
+def check_switch_root_last(self) -> None:
+    """Validates that do_switch_root is the last function in init_final"""
+    if not self["imports"]["init_final"][-1].__name__ == "do_switch_root":
+        raise ValidationError("do_switch_root must be the last function in init_final.")
 
 
 def do_switch_root(self) -> str:

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.2"
+__version__ = "6.6.3"
 
 from pathlib import Path
 from shutil import which
@@ -320,29 +320,29 @@ def klog(self) -> str:
 def edebug(self) -> str:
     """Returns a shell function like edebug."""
     return r"""
+    output="$(printf "%s" "${*}")"
     if check_var quiet; then
         return
     fi
     if [ "$(readvar debug)" != "1" ]; then
         return
     fi
-    printf "\033[1;34m *\033[0m %s\n" "${*}"
+    printf "\033[1;34m *\033[0m %s\n" "${output}"
     """
 
 
 def einfo(self) -> list[str]:
     """Returns a shell function like einfo."""
+    output = ['output="$(printf "%s" "${*}")"']
     if "ugrd.base.plymouth" in self["modules"]:
-        output = [
+        output += [
             "if plymouth --ping; then",
-            '    plymouth display-message --text="${*}"',
+            '    plymouth display-message --text="${output}"',
             "    return",
             "fi",
         ]
-    else:
-        output = []
 
-    output += ["if check_var quiet; then", "    return", "fi", r'printf "\033[1;32m *\033[0m %s\n" "${*}"']
+    output += ["if check_var quiet; then", "    return", "fi", r'printf "\033[1;32m *\033[0m %s\n" "${output}"']
     return output
 
 
@@ -350,34 +350,34 @@ def ewarn(self) -> list[str]:
     """Returns a shell function like ewarn.
     If plymouth is running, it displays a message instead of echoing.
     """
+    output = ['output="$(printf "%s" "${*}")"']
     if "ugrd.base.plymouth" in self["modules"]:
-        output = [
+        output += [
             "if plymouth --ping; then",  # Always show the message if plymouth is running
-            '    plymouth display-message --text="Warning: ${*}"',
+            '    plymouth display-message --text="Warning: ${output}"',
             "    return",  # Return early so echo doesn't leak
             "fi",
         ]
-    else:
-        output = []
 
     output += [
         "if check_var quiet; then",
         "    return",
         "fi",
-        r'printf "\033[1;33m *\033[0m %s\n" "${*}"',
+        r'printf "\033[1;33m *\033[0m %s\n" "${output}"',
     ]
     return output
 
 
-def eerror(self) -> str:
+def eerror(self) -> list[str]:
     """Returns a shell function like eerror."""
+    output = ['output="$(printf "%s" "${*}")"']
     if "ugrd.base.plymouth" in self["modules"]:
-        return r"""
-        if plymouth --ping; then
-            plymouth display-message --text="Error: ${*}"
-            return
-        fi
-        printf "\033[1;31m *\033[0m %s\n" "${*}"
-        """
+        output += [
+            "if plymouth --ping; then",
+            '    plymouth display-message --text="Error: ${output}"',
+            "    return",
+            "fi",
+        ]
     else:
-        return r'printf "\033[1;31m *\033[0m %s\n" "${*}"'
+        output += [r'printf "\033[1;31m *\033[0m %s\n" "${output}"']
+    return output

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -37,6 +37,9 @@ autodetect_init = true
                      "klog", "edebug", "einfo", "ewarn", "eerror",
 		     "rd_fail", "rd_restart", "_find_init" ]
 
+[imports.checks]
+"ugrd.base.base" = [ "check_init_target" ]
+
 [import_order.after]
 set_loglevel = "parse_cmdline"
 

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -15,7 +15,7 @@ shebang_args = "-l"
 autodetect_init = true
 
 [imports.config_processing]
-"ugrd.base.base" = [ "_process_loglevel", "_process_init_target", "_process_autodetect_init" ]
+"ugrd.base.base" = [ "_process_loglevel", "_process_init_target" ]
 
 [imports.build_enum]
 "ugrd.base.base" = [ "autodetect_init" ]

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -23,7 +23,7 @@ autodetect_init = true
 [imports.build_tasks]
 "ugrd.base.base" = [ "set_shebang", "export_switch_root_target" ]
 
-[imports.init_early]
+[imports.init_pre]
 "ugrd.base.base" = [ "set_loglevel" ]
 
 [imports.init_final]
@@ -33,6 +33,9 @@ autodetect_init = true
 "ugrd.base.base" = [ "check_var", "setvar", "readvar", "wait_enter", "prompt_user", "retry",
                      "klog", "edebug", "einfo", "ewarn", "eerror",
 		     "rd_fail", "rd_restart", "_find_init" ]
+
+[import_order.after]
+set_loglevel = "parse_cmdline"
 
 [custom_parameters]
 switch_root_target = "Path"  # Specifies the location of the new root filesystem

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -38,7 +38,7 @@ autodetect_init = true
 		     "rd_fail", "rd_restart", "_find_init" ]
 
 [imports.checks]
-"ugrd.base.base" = [ "check_init_target" ]
+"ugrd.base.base" = [ "check_init_target", "check_switch_root_last" ]
 
 [import_order.after]
 set_loglevel = "parse_cmdline"

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -6,7 +6,7 @@ modules = [ "ugrd.base.core",
 	    "ugrd.fs.cpio",
 	    "ugrd.base.checks" ]
 
-binaries = [ "awk", "bc", "dd", "grep", "ls", "cp", "cat", "stty", "switch_root" ]
+binaries = [ "awk", "bc", "dd", "grep", "ls", "cp", "cat", "stty", "switch_root", "rm" ]
 
 paths = [ "root", "tmp" ]
 

--- a/src/ugrd/base/base.toml
+++ b/src/ugrd/base/base.toml
@@ -23,6 +23,9 @@ autodetect_init = true
 [imports.build_tasks]
 "ugrd.base.base" = [ "set_shebang", "export_switch_root_target" ]
 
+[imports.build_final]
+"ugrd.base.base" = [ "set_init_final_order" ]
+
 [imports.init_pre]
 "ugrd.base.base" = [ "set_loglevel" ]
 

--- a/src/ugrd/base/checks.toml
+++ b/src/ugrd/base/checks.toml
@@ -1,7 +1,7 @@
 check_included_funcs = true
 
 [imports.checks]
-"ugrd.base.checks" = [ "check_included_funcs", "check_in_file", "check_included_or_mounted" ]
+"ugrd.base.checks" = [ "check_init_order", "check_included_funcs", "check_in_file", "check_included_or_mounted" ]
 
 [custom_parameters]
 check_included_funcs = 'bool'  # Checks that all included functions are in the profile

--- a/src/ugrd/base/cmdline.py
+++ b/src/ugrd/base/cmdline.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 
 
 def parse_cmdline_bool(self) -> str:
@@ -31,32 +31,13 @@ def parse_cmdline(self) -> str:
     return rf"""
     cmdline=$(awk -F '--' '{{print $1}}' /proc/cmdline)  # Get everything before '--'
     setvar INIT_ARGS "$(awk -F '--' '{{print $2}}' /proc/cmdline)"  # Get everything after '--'
-    for bool in {" ".join([f'"{bool}"' for bool in self['cmdline_bools']])}; do
+    for bool in {" ".join([f'"{bool}"' for bool in self["cmdline_bools"]])}; do
         parse_cmdline_bool "$bool"
     done
-    for string in {" ".join([f'"{string}"' for string in self['cmdline_strings']])}; do
+    for string in {" ".join([f'"{string}"' for string in self["cmdline_strings"]])}; do
         parse_cmdline_str "$string"
     done
     einfo "Parsed cmdline: $cmdline"
-    """
-
-
-def mount_cmdline_root(self) -> str:
-    """Returns shell script to mount root partition based on /proc/cmdline"""
-    return """
-    root=$(readvar root)
-    if [ -z "$root" ]; then
-        edebug "No root partition specified in /proc/cmdline, falling back to mount_root"
-        mount_root
-        return
-    fi
-    roottype="$(readvar roottype auto)"
-    rootflags="$(readvar rootflags 'defaults,ro')"
-    einfo "Mounting root partition based on /proc/cmdline: $root -t $roottype -o $rootflags"
-    if ! mount "$root" "$(readvar MOUNTS_ROOT_TARGET)" -t "$roottype" -o "$rootflags"; then
-        eerror "Failed to mount the root partition using /proc/cmdline: $root -t $roottype -o $rootflags"
-        mount_root
-    fi
     """
 
 

--- a/src/ugrd/base/cmdline.toml
+++ b/src/ugrd/base/cmdline.toml
@@ -11,6 +11,10 @@ cmdline_strings = ['init', 'loglevel']
 [imports.functions]
 "ugrd.base.cmdline" = [ "parse_cmdline_bool", "parse_cmdline_str" ]
 
+[import_order.after]
+export_exports = "make_run_dirs"
+parse_cmdline = "export_exports"
+
 [custom_parameters]
 exports = "dict"  # Add the exports property, used to specify the exports for the init script
 cmdline_bools = "NoDupFlatList" # set the booleans to be procesed from /proc/cmdline

--- a/src/ugrd/base/cmdline.toml
+++ b/src/ugrd/base/cmdline.toml
@@ -5,9 +5,6 @@ cmdline_strings = ['init', 'loglevel']
 [imports.init_pre]
 "ugrd.base.cmdline" = [ "export_exports", "parse_cmdline" ]
 
-[imports.init_mount]
-"ugrd.base.cmdline" = [ "mount_cmdline_root" ]
-
 [imports.functions]
 "ugrd.base.cmdline" = [ "parse_cmdline_bool", "parse_cmdline_str" ]
 

--- a/src/ugrd/base/compat.toml
+++ b/src/ugrd/base/compat.toml
@@ -1,0 +1,4 @@
+[nodes.console]
+mode = 0o644
+major = 5
+minor = 1

--- a/src/ugrd/base/console.toml
+++ b/src/ugrd/base/console.toml
@@ -1,5 +1,4 @@
 binaries = [ "agetty" ]
-_custom_init_file = "init_main.sh"
 
 # Define the primary console
 primary_console = "tty0"

--- a/src/ugrd/base/core.py
+++ b/src/ugrd/base/core.py
@@ -1,8 +1,11 @@
 __author__ = "desultory"
 __version__ = "4.1.3"
 
+from os import environ, makedev, mknod
 from pathlib import Path
 from shutil import rmtree, which
+from stat import S_IFCHR
+from subprocess import run
 from typing import Union
 
 from ugrd import AutodetectError, ValidationError
@@ -10,10 +13,8 @@ from zenlib.types import NoDupFlatList
 from zenlib.util import colorize, contains, unset
 
 
-def detect_tmpdir(self) -> None:
+def get_tmpdir(self) -> None:
     """Reads TMPDIR from the environment, sets it as the temporary directory."""
-    from os import environ
-
     if tmpdir := environ.get("TMPDIR"):
         self.logger.info("Detected TMPDIR: %s" % (colorize(tmpdir, "cyan")))
         self["tmpdir"] = Path(tmpdir)
@@ -57,11 +58,10 @@ def generate_structure(self) -> None:
         self._mkdir(subdir)
 
 
-def add_conditional_dependencies(self) -> None:
+def get_conditional_dependencies(self) -> None:
     """Adds conditional dependencies to the dependencies list.
     Keys are the dependency, values are a tuple of the condition type and value.
     """
-
     def add_dep(dep: str) -> None:
         try:  # Try to add it as a binary, if it fails, add it as a dependency
             self["binaries"] = dep
@@ -82,8 +82,6 @@ def calculate_dependencies(self, binary: str) -> list[Path]:
     :param binary: The binary to calculate dependencies for
     :return: A list of dependency paths
     """
-    from subprocess import run
-
     binary_path = which(binary)
     if not binary_path:
         raise AutodetectError("'%s' not found in PATH" % binary)
@@ -193,9 +191,6 @@ def deploy_symlinks(self) -> None:
 @contains("make_nodes", "Skipping real device node creation with mknod, as make_nodes is not specified.", log_level=20)
 def deploy_nodes(self) -> None:
     """Generates specified device nodes."""
-    from os import makedev, mknod
-    from stat import S_IFCHR
-
     for node, config in self["nodes"].items():
         node_path_abs = Path(config["path"])
 
@@ -214,12 +209,10 @@ def deploy_nodes(self) -> None:
 
 
 @contains("find_libgcc", "Skipping libgcc_s dependency resolution", log_level=20)
-def find_libgcc(self) -> None:
+def autodetect_libgcc(self) -> None:
     """Finds libgcc.so, adds a 'dependencies' item for it.
     Adds the parent directory to 'library_paths'
     """
-    from pathlib import Path
-
     musl_warning = False
     try:
         cmd = self._run(["ldconfig", "-p"], fail_silent=True, fail_hard=False)

--- a/src/ugrd/base/core.py
+++ b/src/ugrd/base/core.py
@@ -205,6 +205,7 @@ def deploy_symlinks(self) -> None:
         self._symlink(symlink_parameters["source"], symlink_parameters["target"])
 
 
+@contains("nodes", "Skipping device node creation, no nodes are defined.")
 @contains("make_nodes", "Skipping real device node creation with mknod, as make_nodes is not specified.", log_level=20)
 def deploy_nodes(self) -> None:
     """Generates specified device nodes."""

--- a/src/ugrd/base/core.toml
+++ b/src/ugrd/base/core.toml
@@ -34,7 +34,7 @@ minor = 1
 		   ]
 
 [imports.build_enum]
-"ugrd.base.core" = [ "detect_tmpdir", "find_libgcc", "get_shell" ]
+"ugrd.base.core" = [ "get_tmpdir", "autodetect_libgcc", "get_shell" ]
 
 [imports.build_pre]
 "ugrd.base.core" = [ "clean_build_dir" ]
@@ -42,7 +42,7 @@ minor = 1
 [imports.build_deploy]
 "ugrd.base.core" = [ "generate_structure",
 		     "handle_usr_symlinks",  # These should be set first
-		     "add_conditional_dependencies",
+		     "get_conditional_dependencies",
 		     "deploy_dependencies",
 		     "deploy_xz_dependencies",
 		     "deploy_gz_dependencies",

--- a/src/ugrd/base/core.toml
+++ b/src/ugrd/base/core.toml
@@ -11,11 +11,6 @@ library_paths = [ "/lib64" ]
 old_count = 1
 timeout = 15
 
-[nodes.console]
-mode = 0o644
-major = 5
-minor = 1
-
 [imports.config_processing]
 "ugrd.base.core" = [ "_process_build_logging",
 		     "_process_out_file",

--- a/src/ugrd/base/core.toml
+++ b/src/ugrd/base/core.toml
@@ -1,6 +1,7 @@
 tmpdir = "/tmp"
 build_dir = "initramfs_build"
 _build_log_level = 10
+_custom_init_file = "init_main.sh"
 out_dir = "initramfs_out"
 clean = true
 find_libgcc = true

--- a/src/ugrd/base/core.toml
+++ b/src/ugrd/base/core.toml
@@ -20,6 +20,7 @@ minor = 1
 "ugrd.base.core" = [ "_process_build_logging",
 		     "_process_out_file",
 		     "_process_binaries_multi",
+		     "_process_libraries_multi",
 		     "_process_dependencies_multi",
 		     "_process_opt_dependencies_multi",
 		     "_process_xz_dependencies_multi",
@@ -68,6 +69,7 @@ xz_dependencies = "NoDupFlatList"  # XZipped dependencies property, used to defi
 gz_dependencies = "NoDupFlatList"  # GZipped dependencies property, used to define the gzipped dependencies (will be extracted)
 library_paths = "NoDupFlatList"  # library_paths property, used to define the library paths to add to LD_LIBRARY_PATH
 find_libgcc = "bool"  # If true, the initramfs will search for libgcc_s.so.1 and add it to the initramfs
+libraries = "NoDupFlatList"  # Additional libraries, by name, added to the initramfs
 binaries = "NoDupFlatList"  # Binaries which should be included in the intiramfs, dependencies resolved with lddtree
 copies = "dict"  # Copies dict, defines the files to be copied to the initramfs
 nodes = "dict"  # Nodes dict, defines the device nodes to be created

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -19,6 +19,12 @@ start_shell = true
 [imports.init_debug]
 "ugrd.base.debug" = [ "start_shell" ]
 
+[import_order.after]
+"enable_debug" = "parse_cmdline"
+
+[import_order.before]
+"enable_debug" = "set_loglevel"
+
 [custom_parameters]
 start_shell = "bool"  # Start a shell after init_early, before init_pre. Can be enabled by the debug cmdline option.
 editor = "str"  # override editor variable

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -1,4 +1,4 @@
-binaries = ['cp', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
+binaries = ['cp', 'ln', 'mv', 'rm', 'find', 'grep', 'dmesg', 'chmod', 'touch']
 dependencies = [ "/usr/share/terminfo/l/linux" ] # required by most editors
 # EDITOR is determined at build time using (in order):
 # 1. editor config parameter

--- a/src/ugrd/base/debug.toml
+++ b/src/ugrd/base/debug.toml
@@ -7,8 +7,11 @@ dependencies = [ "/usr/share/terminfo/l/linux" ] # required by most editors
 
 start_shell = true
 
+[imports.config_processing]
+"ugrd.base.debug" = [ "_process_editor" ]
+
 [imports.build_enum]
-"ugrd.base.debug" = [ "detect_editor" ]
+"ugrd.base.debug" = [ "autodetect_editor" ]
 
 [imports.init_pre]
 "ugrd.base.debug" = [ "enable_debug" ]

--- a/src/ugrd/base/plymouth.toml
+++ b/src/ugrd/base/plymouth.toml
@@ -5,16 +5,10 @@ dependencies = ['/usr/share/plymouth/plymouthd.defaults',
                 '/usr/share/plymouth/themes/details/details.plymouth']
 
 run_dirs = ["plymouth"]
+mount_devpts = true
 
 [imports.config_processing]
 "ugrd.base.plymouth" = [ "_process_plymouth_themes_multi" ]
-
-[mounts.devpts]
-type = "devpts"
-destination = "/dev/pts"
-options = ['noauto', 'nosuid', 'noexec', 'rw', 'mode=620', 'gid=5']
-no_validate = true
-path = "devpts"
 
 [imports.build_enum]
 "ugrd.base.plymouth" = [ "find_plymouth_config" ]
@@ -23,14 +17,12 @@ path = "devpts"
 "ugrd.base.plymouth" = [ "pull_plymouth" ]
 
 [imports.init_pre]
-"ugrd.base.plymouth" = [ "make_devpts", "start_plymouth" ]
+"ugrd.base.plymouth" = [ "start_plymouth" ]
 
 [import_order.before]
-make_devpts = "start_plymouth"
 start_plymouth = "print_banner"
 
 [import_order.after]
-make_devpts = "mount_base"
 start_plymouth = ["parse_cmdline", "make_run_dirs", "load_modules"]
 
 [custom_parameters]

--- a/src/ugrd/base/plymouth.toml
+++ b/src/ugrd/base/plymouth.toml
@@ -22,8 +22,16 @@ path = "devpts"
 [imports.build_tasks]
 "ugrd.base.plymouth" = [ "pull_plymouth" ]
 
-[imports.init_early]
+[imports.init_pre]
 "ugrd.base.plymouth" = [ "make_devpts", "start_plymouth" ]
+
+[import_order.before]
+make_devpts = "start_plymouth"
+start_plymouth = "print_banner"
+
+[import_order.after]
+make_devpts = "mount_base"
+start_plymouth = ["parse_cmdline", "make_run_dirs", "load_modules"]
 
 [custom_parameters]
 plymouth_config = "Path"  # Path to the plymouth configuration file

--- a/src/ugrd/base/test.py
+++ b/src/ugrd/base/test.py
@@ -1,13 +1,13 @@
 __version__ = "1.2.0"
 
+from pathlib import Path
+from uuid import uuid4
 from zenlib.util import colorize, unset
 
 
 @unset("test_kernel")
 def find_kernel_path(self):
     """Finds the kernel path for the current system"""
-    from pathlib import Path
-
     self.logger.info("Trying to find the kernel path for: %s", colorize(self["kernel_version"], "blue"))
     kernel_path = Path(self["_kmod_dir"]) / "vmlinuz"  # try this first
     if not (self["_kmod_dir"] / "vmlinuz").exists():
@@ -27,8 +27,6 @@ def find_kernel_path(self):
 
 def init_test_vars(self):
     """Initializes the test variables"""
-    from uuid import uuid4
-
     find_kernel_path(self)
     if not self["test_flag"]:
         self["test_flag"] = uuid4()

--- a/src/ugrd/crypto/gpg.toml
+++ b/src/ugrd/crypto/gpg.toml
@@ -1,7 +1,6 @@
 modules = [ "ugrd.base.console", "ugrd.crypto.cryptsetup" ]
 
-binaries = [ "/usr/bin/gpg", "/usr/bin/gpg-agent", "/usr/bin/gpgconf", "/usr/bin/gpg-connect-agent", "/usr/bin/pinentry-tty",
-             "rm" ]  # rm needed to remove the decrypted key file
+binaries = [ "/usr/bin/gpg", "/usr/bin/gpg-agent", "/usr/bin/gpgconf", "/usr/bin/gpg-connect-agent", "/usr/bin/pinentry-tty" ]
 opt_dependencies = [ '/usr/libexec/keyboxd' ]  # Pull keyboxd in as an optional dependency
 
 

--- a/src/ugrd/crypto/gpg.toml
+++ b/src/ugrd/crypto/gpg.toml
@@ -13,8 +13,14 @@ plymouth_key_command = "gpg --batch --pinentry-mode loopback --passphrase-fd 0 -
 source = "/usr/bin/pinentry-tty"
 target = "/usr/bin/pinentry"
 
-[imports.init_early]
+[imports.init_main]
 "ugrd.crypto.gpg" = [ "start_agent" ]
+
+[import_order.before]
+start_agent = "crypt_init"
+
+[import_order.after]
+start_agent = "mount_fstab"
 
 [custom_parameters]
 gpg_agent_args = "NoDupFlatList"  # Arguments to be passed to the gpg-agent

--- a/src/ugrd/crypto/smartcard.toml
+++ b/src/ugrd/crypto/smartcard.toml
@@ -15,6 +15,8 @@ sc_public_key = "Path"  # The path to the public key to import
 [imports.config_processing]
 "ugrd.crypto.smartcard" = [ "_process_sc_public_key" ]
 
-[imports.init_early]
+[imports.init_main]
 "ugrd.crypto.smartcard" = [ "import_keys" ]
 
+[import_order.after]
+import_keys = "start_agent"

--- a/src/ugrd/crypto/smartcard.toml
+++ b/src/ugrd/crypto/smartcard.toml
@@ -20,3 +20,6 @@ sc_public_key = "Path"  # The path to the public key to import
 
 [import_order.after]
 import_keys = "start_agent"
+
+[import_order.before]
+import_keys = "crypt_init"

--- a/src/ugrd/fs/btrfs.py
+++ b/src/ugrd/fs/btrfs.py
@@ -1,11 +1,11 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "desultory"
 
 from pathlib import Path
 
 from ugrd import ValidationError
 from ugrd.fs.mounts import _resolve_overlay_lower_dir
-from zenlib.util import contains, unset, colorize
+from zenlib.util import colorize, contains, unset
 
 
 class SubvolNotFound(Exception):
@@ -103,26 +103,26 @@ def select_subvol(self) -> str:
     # TODO: Figure out a way to make the case prompt more standard
     return f"""
     mount -t btrfs -o subvolid=5,ro $(readvar MOUNTS_ROOT_SOURCE) {self["_base_mount_path"]}
-    if [ -z "$(btrfs subvolume list -o {self['_base_mount_path']})" ]; then
-        ewarn "Failed to list btrfs subvolumes for root volume: {self['_base_mount_path']}"
+    if [ -z "$(btrfs subvolume list -o {self["_base_mount_path"]})" ]; then
+        ewarn "Failed to list btrfs subvolumes for root volume: {self["_base_mount_path"]}"
     else
         echo 'Select a subvolume to use as root'
         PS3='Subvolume: '
-        select subvol in $(btrfs subvolume list -o {self['_base_mount_path']} " + "| awk '{{print $9}}'); do
+        select subvol in $(btrfs subvolume list -o {self["_base_mount_path"]} " + "| awk '{{print $9}}'); do
         case $subvol in
             *)
                 if [[ -z $subvol ]]; then
                     ewarn 'Invalid selection'
                 else
                     einfo "Selected subvolume: $subvol"
-                    printf "%s" ",subvol=$subvol" >> /run/vars/MOUNTS_ROOT_OPTIONS
+                    printf "%s" ",subvol=$subvol" >> /run/ugrd/MOUNTS_ROOT_OPTIONS  # append, don't overwrite
                     break
                 fi
                 ;;
             esac
         done
     fi
-    umount -l {self['_base_mount_path']}
+    umount -l {self["_base_mount_path"]}
     """
 
 
@@ -130,4 +130,4 @@ def select_subvol(self) -> str:
 def set_root_subvol(self) -> str:
     """Adds the root_subvol to the root_mount options."""
     _validate_root_subvol(self)
-    return f"""printf ",subvol={self['root_subvol']}" >> /run/vars/MOUNTS_ROOT_OPTIONS"""
+    return f"""printf ",subvol={self["root_subvol"]}" >> /run/ugrd/MOUNTS_ROOT_OPTIONS"""

--- a/src/ugrd/fs/btrfs.toml
+++ b/src/ugrd/fs/btrfs.toml
@@ -11,8 +11,17 @@ autodetect_root_subvol = true
 [imports.build_pre]
 "ugrd.fs.btrfs" = [ "autodetect_root_subvol" ]
 
-[imports.init_premount]
+[imports.init_mount]
 "ugrd.fs.btrfs" = [ "btrfs_scan", "set_root_subvol", "select_subvol" ]
+
+[import_order.before]
+btrfs_scan = ["set_root_subvol", "mount_cmdline_root", "mount_root"]
+set_root_subvol = ["select_subvol", "mount_cmdline_root", "mount_root"]
+select_subvol = ["mount_cmdline_root", "mount_root"]
+
+[import_order.after]
+mount_cmdline_root = ["btrfs_scan"]
+mount_root = ["btrfs_scan"]
 
 # Custom parameters
 [custom_parameters]

--- a/src/ugrd/fs/btrfs.toml
+++ b/src/ugrd/fs/btrfs.toml
@@ -15,12 +15,11 @@ autodetect_root_subvol = true
 "ugrd.fs.btrfs" = [ "btrfs_scan", "set_root_subvol", "select_subvol" ]
 
 [import_order.before]
-btrfs_scan = ["set_root_subvol", "mount_cmdline_root", "mount_root"]
-set_root_subvol = ["select_subvol", "mount_cmdline_root", "mount_root"]
-select_subvol = ["mount_cmdline_root", "mount_root"]
+btrfs_scan = ["set_root_subvol", "mount_root"]
+set_root_subvol = ["select_subvol", "mount_root"]
+select_subvol = "mount_root"
 
 [import_order.after]
-mount_cmdline_root = ["btrfs_scan"]
 mount_root = ["btrfs_scan"]
 
 # Custom parameters

--- a/src/ugrd/fs/ext4.toml
+++ b/src/ugrd/fs/ext4.toml
@@ -1,8 +1,7 @@
 modules = [ "ugrd.fs.mounts" ]
 kmod_init = [ "ext4" ]
 
-
-[imports.init_cleanup]
+[imports.init_final]
 "ugrd.fs.ext4" = [ "ext4_fsck" ]
 
 [conditional_dependencies]

--- a/src/ugrd/fs/fakeudev.toml
+++ b/src/ugrd/fs/fakeudev.toml
@@ -1,4 +1,7 @@
 run_dirs = ['udev/data']
 
-[imports.init_mount_late]
+[imports.init_mount]
 'ugrd.fs.fakeudev' = ['fake_dm_udev']
+
+[import_order.after]
+fake_dm_udev = ["mount_late", "mount_cmdline_root"]

--- a/src/ugrd/fs/fakeudev.toml
+++ b/src/ugrd/fs/fakeudev.toml
@@ -4,4 +4,4 @@ run_dirs = ['udev/data']
 'ugrd.fs.fakeudev' = ['fake_dm_udev']
 
 [import_order.after]
-fake_dm_udev = ["mount_late", "mount_cmdline_root"]
+fake_dm_udev = ["mount_late", "mount_root"]

--- a/src/ugrd/fs/lvm.py
+++ b/src/ugrd/fs/lvm.py
@@ -1,27 +1,36 @@
 __author__ = "desultory"
-__version__ = "1.5.1"
+__version__ = "2.1.0"
 
-from zenlib.util import contains
+from zenlib.util import colorize, contains
 
 
 def _process_lvm_multi(self, mapped_name: str, config: dict) -> None:
     self.logger.debug("[%s] Processing LVM config: %s" % (mapped_name, config))
     if "uuid" not in config:
         raise ValueError("LVM config missing uuid: %s" % mapped_name)
+    if "holders" in config:
+        if not self["early_lvm"]:
+            self.logger.info(
+                "[%s] LVM volume has holders, enabling early_lvm: %s"
+                % (mapped_name, colorize(", ".join(config["holders"]), "cyan"))
+            )
+            self["early_lvm"] = True
     self["lvm"][mapped_name] = config
 
 
 @contains("early_lvm")
-def early_init_lvm(self) -> None:
-    """Returns shell lines to initialize LVM"""
-    return init_lvm(self)
+@contains("lvm", "Skipping early LVM initialization, no LVM configurations found.", log_level=30)
+def early_lvm(self) -> str:
+    """If early_lvm is set, return a shell function to initialize LVM"""
+    return "init_lvm 'Early initialzing LVM'"
 
 
-@contains("lvm", "Skipping LVM initialization, no LVM configurations found.")
+@contains("lvm", "Skipping LVM initialization, no LVM configurations found.", log_level=30)
 def init_lvm(self) -> str:
     """Returns a shell function to initialize LVM"""
     return f"""
-    einfo "[UGRD] Initializing LVM, ugrd.fs.lvm module version: {__version__}"
+    msg="${{1:-Initializing LVM}}"
+    einfo "[UGRD] "$msg", ugrd.fs.lvm module version: {__version__}"
     einfo "$(vgchange -ay)"
     einfo "$(vgscan --mknodes)"
     """

--- a/src/ugrd/fs/lvm.toml
+++ b/src/ugrd/fs/lvm.toml
@@ -1,13 +1,17 @@
 binaries = ['pvscan', 'vgscan', 'vgchange', 'lvscan']
 
 [imports.config_processing]
-"ugrd.fs.lvm" = [ "_process_lvm_multi" ]
+"ugrd.fs.lvm" = [ "_process_lvm_multi" ] 
 
-[imports.init_early]
-"ugrd.fs.lvm" = [ "early_init_lvm" ]
+[imports.init_main]
+"ugrd.fs.lvm" = [ "early_lvm", "init_lvm" ]
 
-[imports.init_late]
-"ugrd.fs.lvm" = [ "init_lvm" ]
+[import_order.before]
+"early_lvm" = "mount_fstab"
+
+[import_order.after]
+"early_lvm" = "md_init"
+"init_lvm" = ["early_lvm", "crypt_init"]
 
 [custom_parameters]
 early_lvm = "bool"  # Run an early lvm scan

--- a/src/ugrd/fs/mdraid.toml
+++ b/src/ugrd/fs/mdraid.toml
@@ -1,5 +1,8 @@
 binaries = ['mdadm']
 dependencies = ['/etc/mdadm.conf']
 
-[imports.init_early]
+[imports.init_main]
 "ugrd.fs.mdraid" = [ "md_init" ]
+
+[import_order.before]
+md_init = "mount_fstab"

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.6.0"
+__version__ = "6.6.1"
 
 from pathlib import Path
 from typing import Union
@@ -800,12 +800,21 @@ def check_mounts(self) -> None:
 def mount_default_root(self) -> str:
     """Mounts the root partition to $MOUNTS_ROOT_TARGET."""
     return f"""
-    if grep -qs "$(readvar MOUNTS_ROOT_TARGET)" /proc/mounts; then
-        ewarn "Root mount already exists, unmounting: $(readvar MOUNTS_ROOT_TARGET)"
-        umount "$(readvar MOUNTS_ROOT_TARGET)"
+    mount_source=$(readvar MOUNTS_ROOT_SOURCE)
+    mount_type=$(readvar MOUNTS_ROOT_TYPE auto)
+    mount_options=$(readvar MOUNTS_ROOT_OPTIONS 'defaults,ro')
+    mount_target=$(readvar MOUNTS_ROOT_TARGET)
+    if grep -qs "$mount_target" /proc/mounts; then
+        ewarn "Root mount already exists, adding 'remount' option: $mount_options"
+        mount_options="remount,$mount_options"
     fi
-    einfo "Mounting '$(readvar MOUNTS_ROOT_SOURCE)' ($(readvar MOUNTS_ROOT_TYPE)) to '$(readvar MOUNTS_ROOT_TARGET)' with options: $(readvar MOUNTS_ROOT_OPTIONS)"
-    retry {self["mount_retries"] or -1} {self["mount_timeout"]} mount "$(readvar MOUNTS_ROOT_SOURCE)" -t "$(readvar MOUNTS_ROOT_TYPE)" "$(readvar MOUNTS_ROOT_TARGET)" -o "$(readvar MOUNTS_ROOT_OPTIONS)"
+    einfo "[/] Mounting '$mount_source' ($mount_type) to '$mount_target' with options: $mount_options"
+    while ! mount "$mount_source" -t "$mount_type" -o "$mount_options" "$mount_target"; do
+        eerror "Failed to mount root partition."
+        if prompt_user "Press enter to break, waiting: {self["mount_timeout"]}s" {self["mount_timeout"]}; then
+            rd_fail "Failed to mount root partition."
+        fi
+    done
     """
 
 

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -540,11 +540,17 @@ def autodetect_lvm(self, source_dev, dm_num, blkid_info) -> None:
         self.logger.info("Autodetected LVM mount, enabling the %s module." % colorize("lvm", "cyan"))
         self["modules"] = "ugrd.fs.lvm"
 
+    lvm_config = {}
     if uuid := blkid_info.get("uuid"):
         self.logger.info("[%s] LVM volume contianer uuid: %s" % (source_dev.name, colorize(uuid, "cyan")))
-        self["lvm"] = {self["_vblk_info"][dm_num]["name"]: {"uuid": uuid}}
+        lvm_config["uuid"] = uuid
     else:
-        raise AutodetectError("Failed to autodetect LVM volume uuid: %s" % source_dev.name)
+        raise AutodetectError("Failed to autodetect LVM volume uuid for device: %s" % colorize(source_dev.name, "red"))
+
+    if holders := self["_vblk_info"][dm_num]["holders"]:
+        lvm_config["holders"] = holders
+
+    self["lvm"] = {source_dev.name: lvm_config}
 
 
 @contains("autodetect_root_luks", "Skipping LUKS autodetection, autodetect_root_luks is disabled.", log_level=30)

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -683,7 +683,7 @@ def autodetect_mounts(self) -> None:
 
 def mount_base(self) -> list[str]:
     """Generates mount commands for the base mounts.
-    Must be run before variables are used, as it creates the /run/vars directory.
+    Must be run before variables are used, as it creates the /run/ugrd directory.
     """
     out = []
     for mount_name, mount_info in self["mounts"].items():

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -342,9 +342,9 @@ def get_blkid_info(self, device=None) -> dict:
     return self["_blkid_info"][device] if device else self["_blkid_info"]
 
 
-@contains("init_target", "init_target must be set", raise_exception=True)
-@contains("autodetect_init_mount", "Init mount autodetection disabled, skipping.", log_level=30)
 @contains("hostonly", "Skipping init mount autodetection, hostonly mode is disabled.", log_level=30)
+@contains("autodetect_init_mount", "Init mount autodetection disabled, skipping.", log_level=30)
+@contains("init_target", "init_target must be set", raise_exception=True)
 def autodetect_init_mount(self) -> None:
     """Checks the parent directories of init_target, if the path is a mountpoint, add it to late_mounts."""
     init_mount = _find_mountpoint(self, self["init_target"])

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "6.5.0"
+__version__ = "6.6.0"
 
 from pathlib import Path
 from typing import Union
@@ -42,7 +42,8 @@ def _resolve_dev(self, device_path) -> str:
     device_path = _resolve_overlay_lower_device(self, mountpoint)
     mountpoint = _resolve_device_mountpoint(self, device_path)  # May have changed if it was an overlayfs
 
-    major, minor = _get_device_id(self["_mounts"][mountpoint]["device"])
+    mount_dev = self["_mounts"][mountpoint]["device"]
+    major, minor = _get_device_id(mount_dev.split(":")[0] if ":" in mount_dev else mount_dev)
     for device in self["_blkid_info"]:
         check_major, check_minor = _get_device_id(device)
         if (major, minor) == (check_major, check_minor):
@@ -71,7 +72,8 @@ def _resolve_device_mountpoint(self, device) -> str:
     for mountpoint, mount_info in self["_mounts"].items():
         if str(device) == mount_info["device"]:
             return mountpoint
-    raise AutodetectError("Device mountpoint not found: %s" % device)
+    self.logger.error("Mount info:\n%s" % pretty_print(self["_mounts"]))
+    raise AutodetectError("Device mountpoint not found: %s" % repr(device))
 
 
 def _resolve_overlay_lower_dir(self, mountpoint) -> str:
@@ -602,43 +604,39 @@ def autodetect_luks(self, source_dev, dm_num, blkid_info) -> None:
 def autodetect_root(self) -> None:
     """Sets self['mounts']['root']'s source based on the host mount."""
     if "/" not in self["_mounts"]:
-        self.logger.error("Host mounts: %s" % pretty_print(self["_mounts"]))
+        self.logger.error("Host mounts:\n%s" % pretty_print(self["_mounts"]))
         raise AutodetectError(
             "Root mount not found in host mounts.\nCurrent mounts: %s" % pretty_print(self["_mounts"])
         )
-    # Sometimes the root device listed in '/proc/mounts' differs from the blkid info
-    root_dev = _resolve_dev(self, self["_mounts"]["/"]["device"])
-    if ":" in root_dev:  # only use the first device
-        root_dev = root_dev.split(":")[0]
-        for alt_devices in root_dev.split(":")[1:]:  # But ensure kmods are loaded for all devices
-            autodetect_mount_kmods(self, alt_devices)
-    _autodetect_mount(self, "/")
+    root_dev = _autodetect_mount(self, "/")
     if self["autodetect_root_dm"]:
         if self["mounts"]["root"]["type"] == "btrfs":
             from ugrd.fs.btrfs import _get_btrfs_mount_devices
-
+            # Btrfs volumes may be backed by multiple dm devices
             for device in _get_btrfs_mount_devices(self, "/", root_dev):
                 _autodetect_dm(self, "/", device)
         else:
             _autodetect_dm(self, "/")
 
 
-def _autodetect_mount(self, mountpoint) -> None:
-    """Sets mount config for the specified mountpoint."""
+def _autodetect_mount(self, mountpoint) -> str:
+    """Sets mount config for the specified mountpoint.
+    Returns the "real" device path for the mountpoint.
+    """
     if mountpoint not in self["_mounts"]:
-        self.logger.error("Host mounts: %s" % pretty_print(self["_mounts"]))
+        self.logger.error("Host mounts:\n%s" % pretty_print(self["_mounts"]))
         raise AutodetectError("auto_mount mountpoint not found in host mounts: %s" % mountpoint)
 
-    mount_device = _resolve_overlay_lower_device(self, mountpoint)  # Just resolve the overlayfs device
+    mount_device = _resolve_dev(self, self["_mounts"][mountpoint]["device"])
+    mount_info = self["_blkid_info"][mount_device]
 
     if ":" in mount_device:  # Handle bcachefs
+        for alt_devices in mount_device.split(":"):
+            autodetect_mount_kmods(self, alt_devices)
         mount_device = mount_device.split(":")[0]
+    else:
+        autodetect_mount_kmods(self, mount_device)
 
-    if mount_device not in self["_blkid_info"]:  # Try to get the blkid info
-        get_blkid_info(self, mount_device)  # Raises an exception if it fails
-
-    mount_info = self["_blkid_info"][mount_device]
-    autodetect_mount_kmods(self, mount_device)
     mount_name = "root" if mountpoint == "/" else mountpoint.removeprefix("/")
     if mount_name in self["mounts"] and any(s_type in self["mounts"][mount_name] for s_type in SOURCE_TYPES):
         return self.logger.warning(
@@ -663,6 +661,7 @@ def _autodetect_mount(self, mountpoint) -> None:
         raise AutodetectError("[%s] Failed to autodetect mount source." % mountpoint)
 
     self["mounts"] = mount_config
+    return mount_device
 
 
 @contains("auto_mounts", "Skipping auto mounts, auto_mounts is empty.", log_level=10)

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -46,16 +46,16 @@ late_fstab = "/etc/fstab.late"
 "ugrd.fs.mounts" = [ "mount_fstab" ]
 
 [imports.init_mount]
-"ugrd.fs.mounts" = [ "mount_late" ]
+"ugrd.fs.mounts" = [ "mount_root" ]
 
 [imports.functions]
-"ugrd.fs.mounts" = [ "mount_root" ]
+"ugrd.fs.mounts" = [ "mount_default_root" ]
 
 [imports.init_final]
 "ugrd.fs.mounts" = [ "umount_fstab" ]
 
 [import_order.after]
-mount_late = ["mount_root", "mount_cmdline_root"]
+mount_late = "mount_root"
 make_run_dirs = "mount_base"
 
 [custom_parameters]

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -48,7 +48,7 @@ late_fstab = "/etc/fstab.late"
 [imports.functions]
 "ugrd.fs.mounts" = [ "mount_root" ]
 
-[imports.init_cleanup]
+[imports.init_final]
 "ugrd.fs.mounts" = [ "umount_fstab" ]
 
 [import_order.after]

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -42,14 +42,18 @@ late_fstab = "/etc/fstab.late"
 [imports.init_main]
 "ugrd.fs.mounts" = [ "mount_fstab" ]
 
+[imports.init_mount]
+"ugrd.fs.mounts" = [ "mount_late" ]
+
 [imports.functions]
 "ugrd.fs.mounts" = [ "mount_root" ]
 
-[imports.init_mount_late]
-"ugrd.fs.mounts" = [ "mount_late" ]
-
 [imports.init_cleanup]
 "ugrd.fs.mounts" = [ "umount_fstab" ]
+
+[import_order.after]
+mount_late = ["mount_root", "mount_cmdline_root"]
+make_run_dirs = "mount_base"
 
 [custom_parameters]
 mounts = "dict"  # Add the mounts property, used to define the mounts to be made in the fstab

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -7,6 +7,8 @@ binaries = [
   "mkdir",
 ]
 
+provides = "mounts" 
+
 cmdline_strings =  ["root", "roottype", "rootflags", "rootdelay" ]
 cmdline_bools = ["no_fsck"]
 

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -34,7 +34,10 @@ late_fstab = "/etc/fstab.late"
 "ugrd.fs.mounts" = [ "export_mount_info" ]
 
 [imports.build_final]
-"ugrd.fs.mounts" = [ "check_mounts", "generate_fstab" ]
+"ugrd.fs.mounts" = [ "generate_fstab" ]
+
+[imports.checks]
+"ugrd.fs.mounts" = [ "check_mounts" ]
 
 [imports.init_pre]
 "ugrd.fs.mounts" = [ "mount_base", "make_run_dirs" ]

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -10,7 +10,7 @@ binaries = [
 cmdline_strings =  ["root", "roottype", "rootflags", "rootdelay" ]
 cmdline_bools = ["no_fsck"]
 
-run_dirs = [ "vars" ]
+run_dirs = [ "ugrd" ]
 
 mount_timeout = 1
 autodetect_root = true

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -60,6 +60,7 @@ make_run_dirs = "mount_base"
 
 [custom_parameters]
 mounts = "dict"  # Add the mounts property, used to define the mounts to be made in the fstab
+mount_devpts = "bool"  # Whether or not to mount devpts
 run_dirs = "NoDupFlatList"  # A list of directories to be created under /run
 late_mounts = "dict"  # Like mounts, but run after the root is mounted
 late_fstab = "str"  # The path to the late_fstab file
@@ -103,6 +104,13 @@ base_mount = true
 type = "devtmpfs"
 path = "devtmpfs"
 options = ['nosuid', 'mode=0755']
+base_mount = true
+
+[mounts.devpts]
+type = "devpts"
+path = "devpts"
+destination = "/dev/pts"
+options = ['noauto', 'nosuid', 'noexec', 'rw', 'mode=620', 'gid=5']
 base_mount = true
 
 [mounts.run]

--- a/src/ugrd/fs/resume.toml
+++ b/src/ugrd/fs/resume.toml
@@ -1,4 +1,7 @@
 cmdline_strings = [ "resume" ]
 
-[imports.init_early] 
+[imports.init_main] 
 "ugrd.fs.resume" = [ "handle_resume" ]
+
+[import_order.before]
+handle_resume = "mount_fstab"

--- a/src/ugrd/generator_helpers.py
+++ b/src/ugrd/generator_helpers.py
@@ -1,10 +1,11 @@
 from pathlib import Path
+from shutil import copy2
 from subprocess import CompletedProcess, TimeoutExpired, run
 from typing import Union
 
-from zenlib.util import pretty_print, colorize
+from zenlib.util import colorize, pretty_print
 
-__version__ = "1.5.5"
+__version__ = "1.6.0"
 __author__ = "desultory"
 
 
@@ -65,29 +66,34 @@ class GeneratorHelpers:
         else:
             self.logger.debug("Directory already exists: %s" % path_dir)
 
-    def _write(self, file_name: Union[Path, str], contents: list[str], chmod_mask=0o644) -> None:
+    def _write(self, file_name: Union[Path, str], contents: list[str], chmod_mask=0o644, append=False) -> None:
         """
         Writes a file within the build directory.
         Sets the passed chmod_mask.
         If the first line is a shebang, sh -n is run on the file.
         """
-        from os import chmod
-
         file_path = self._get_build_path(file_name)
 
         if not file_path.parent.is_dir():
             self.logger.debug("Parent directory for '%s' does not exist: %s" % (file_path.name, file_path))
             self._mkdir(file_path.parent, resolve_build=False)
 
+        if isinstance(contents, list):
+            contents = "\n".join(contents)
+
         if file_path.is_file():
             self.logger.warning("File already exists: %s" % colorize(file_path, "yellow"))
-            if self.clean:
+            if contents in file_path.read_text():
+                self.logger.debug("Contents:\n%s" % contents)
+                return self.logger.warning("Contents are already present, skipping write: %s" % file_path)
+
+            if self.clean and not append:
                 self.logger.warning("Deleting file: %s" % colorize(file_path, "red", bright=True, bold=True))
                 file_path.unlink()
 
         self.logger.debug("[%s] Writing contents:\n%s" % (file_path, contents))
-        with open(file_path, "w") as file:
-            file.writelines("\n".join(contents))
+        with open(file_path, "a") as file:
+            file.write(contents)
 
         if contents[0].startswith(self["shebang"].split(" ")[0]):
             self.logger.debug("Running sh -n on file: %s" % file_name)
@@ -99,7 +105,7 @@ class GeneratorHelpers:
             self.logger.warning("[%s] Skipping sh -n on file with unrecognized shebang: %s" % (file_name, contents[0]))
 
         self.logger.info("Wrote file: %s" % colorize(file_path, "green", bright=True))
-        chmod(file_path, chmod_mask)
+        file_path.chmod(chmod_mask)
         self.logger.debug("[%s] Set file permissions: %s" % (file_path, chmod_mask))
 
     def _copy(self, source: Union[Path, str], dest=None) -> None:
@@ -111,8 +117,6 @@ class GeneratorHelpers:
 
         Raises a RuntimeError if the destination path is not within the build directory.
         """
-        from shutil import copy2
-
         if not isinstance(source, Path):
             source = Path(source)
 

--- a/src/ugrd/generator_helpers.py
+++ b/src/ugrd/generator_helpers.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from zenlib.util import colorize, pretty_print
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 __author__ = "desultory"
 
 
@@ -202,6 +202,8 @@ class GeneratorHelpers:
         try:
             cmd = run(cmd_args, capture_output=True, timeout=timeout)
         except TimeoutExpired as e:
+            self.logger.error("Command output:\n%s" % e.stdout.decode())
+            self.logger.error("Command error:\n%s" % e.stderr.decode())
             raise RuntimeError("[%ds] Command timed out: %s" % (timeout, [str(arg) for arg in cmd_args])) from e
 
         if cmd.returncode != 0:

--- a/src/ugrd/initramfs_dict.py
+++ b/src/ugrd/initramfs_dict.py
@@ -1,7 +1,9 @@
 __author__ = "desultory"
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 
 from collections import UserDict
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from queue import Queue
 from tomllib import TOMLDecodeError, load
@@ -64,7 +66,9 @@ class InitramfsConfigDict(UserDict):
 
     def __setitem__(self, key: str, value) -> None:
         if self["validated"]:
-            return self.logger.error("[%s] Config is validated, refusing to set value: %s" % (key, colorize(value, "red")))
+            return self.logger.error(
+                "[%s] Config is validated, refusing to set value: %s" % (key, colorize(value, "red"))
+            )
         # If the type is registered, use the appropriate update function
         if any(key in d for d in (self.builtin_parameters, self["custom_parameters"])):
             return self.handle_parameter(key, value)
@@ -190,8 +194,6 @@ class InitramfsConfigDict(UserDict):
     @handle_plural
     def _process_imports(self, import_type: str, import_value: dict) -> None:
         """Processes imports in a module, importing the functions and adding them to the appropriate list."""
-        from importlib import import_module
-        from importlib.util import module_from_spec, spec_from_file_location
 
         for module_name, function_names in import_value.items():
             self.logger.debug("[%s]<%s> Importing module functions : %s" % (module_name, import_type, function_names))
@@ -225,8 +227,7 @@ class InitramfsConfigDict(UserDict):
                 else:
                     self["imports"]["custom_init"] = function_list[0]
                     self.logger.info(
-                        "Registered custom init function: %s"
-                        % colorize(function_list[0].__name__, "blue", bold=True)
+                        "Registered custom init function: %s" % colorize(function_list[0].__name__, "blue", bold=True)
                     )
                     continue
 
@@ -248,7 +249,7 @@ class InitramfsConfigDict(UserDict):
 
     @handle_plural
     def _process_modules(self, module: str) -> None:
-        """ processes a single module into the config """
+        """processes a single module into the config"""
         if module in self["modules"]:
             self.logger.debug("Module '%s' already loaded" % module)
             return
@@ -296,7 +297,10 @@ class InitramfsConfigDict(UserDict):
     def validate(self) -> None:
         """Validate config, checks that all values are processed, sets validated flag."""
         if self["_processing"]:
-            self.logger.critical("Unprocessed config values: %s" % colorize(", ".join(list(self["_processing"].keys())), "red", bold=True))
+            self.logger.critical(
+                "Unprocessed config values: %s"
+                % colorize(", ".join(list(self["_processing"].keys())), "red", bold=True)
+            )
         self["validated"] = True
 
     def __str__(self) -> str:

--- a/src/ugrd/initramfs_dict.py
+++ b/src/ugrd/initramfs_dict.py
@@ -271,7 +271,21 @@ class InitramfsConfigDict(UserDict):
                 self.logger.log(5, "Creating import type: %s" % import_type)
                 self["imports"][import_type] = NoDupFlatList(_log_bump=10, logger=self.logger)
 
+            if import_masks := self.get("masks", {}).get(import_type, {}).get(module_name):
+                import_masks = [import_masks] if isinstance(import_masks, str) else import_masks
+                for mask in import_masks:
+                    if mask in function_names:
+                        self.logger.warning("[%s] Skipping import of masked function: %s" % (module_name, mask))
+                        function_names.remove(mask)
+                        if import_type == "custom_init":
+                            self.logger.warning("Skipping custom init function: %s" % mask)
+                            continue
+
             function_list = self._process_import_functions(module, function_names)
+            if not function_list:
+                self.logger.warning("[%s] No functions found for import: %s" % (module_name, import_type))
+                continue
+
             if import_type == "custom_init":  # Only get the first function for custom init (should be 1)
                 if isinstance(function_list, list):
                     custom_init = function_list[0]

--- a/src/ugrd/initramfs_generator.py
+++ b/src/ugrd/initramfs_generator.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version
 from tomllib import TOMLDecodeError, load
 
 from zenlib.logging import loggify
@@ -20,23 +21,19 @@ class InitramfsGenerator(GeneratorHelpers):
         self.build_tasks = ["build_enum", "build_pre", "build_tasks", "build_late", "build_deploy", "build_final"]
 
         # init_pre and init_final are run as part of generate_initramfs_main
-        self.init_types = [
-            "init_debug",
-            "init_main",
-            "init_mount",
-        ]
+        self.init_types = ["init_debug", "init_main", "init_mount"]
 
         # Passed kwargs must be imported early, so they will be processed against the base configuration
         self.config_dict.import_args(kwargs)
-        try:
+        try:  # Attempt to load the config file, if it exists
             self.load_config(config)  # The user config is loaded over the base config, clobbering kwargs
             self.config_dict.import_args(
                 kwargs, quiet=True
             )  # Re-import kwargs (cmdline params) to apply them over the config
         except FileNotFoundError:
-            if config:
-                self.logger.warning("[%s] Config file not found, using the base config." % config)
-            else:
+            if config:  # If a config file was specified, log an error that it's missing
+                self.logger.critical("[%s] Config file not found, using the base config." % config)
+            else:  # Otherwise, log info that the base config is being used
                 self.logger.info("No config file specified, using the base config.")
         except TOMLDecodeError as e:
             raise ValueError("[%s] Error decoding config file: %s" % (config, e))
@@ -64,6 +61,7 @@ class InitramfsGenerator(GeneratorHelpers):
 
         self.logger.debug("Loaded config:\n%s" % self.config_dict)
 
+    #  If the initramfs generator is used as a dictionary, it will use the config_dict.
     def __setitem__(self, key, value):
         self.config_dict[key] = value
 
@@ -84,8 +82,6 @@ class InitramfsGenerator(GeneratorHelpers):
 
     def build(self) -> None:
         """Builds the initramfs image."""
-        from importlib.metadata import version
-
         self._log_run(f"Running ugrd v{version('ugrd')}")
         self.run_build()
         self.config_dict.validate()  # Validate the config after the build tasks have been run
@@ -180,7 +176,7 @@ class InitramfsGenerator(GeneratorHelpers):
                     assert other_index >= 0, "Function not found in import list: %s" % other_func
 
                     def reorder_func(direction):
-                        """ Reorders the function based on the direction. """
+                        """Reorders the function based on the direction."""
                         self.logger.debug("Moving %s %s %s" % (func_name, direction, other_func))
                         if direction == "before":  # Move the function before the other function
                             self.logger.debug("[%s] Moving function before: %s" % (func_name, other_func))
@@ -215,7 +211,9 @@ class InitramfsGenerator(GeneratorHelpers):
         while iterations:
             iterations -= 1
             if not any([iter_order(before, "before"), iter_order(after, "after")]):
-                self.logger.debug("[%s] Import order converged after %s iterations" % (hook, max_iterations - iterations))
+                self.logger.debug(
+                    "[%s] Import order converged after %s iterations" % (hook, max_iterations - iterations)
+                )
                 break  # Keep going until no changes are made
         else:
             self.logger.error("Import list: %s" % func_names)

--- a/src/ugrd/initramfs_generator.py
+++ b/src/ugrd/initramfs_generator.py
@@ -23,9 +23,7 @@ class InitramfsGenerator(GeneratorHelpers):
         self.init_types = [
             "init_debug",
             "init_main",
-            "init_late",
             "init_mount",
-            "init_cleanup",
         ]
 
         # Passed kwargs must be imported early, so they will be processed against the base configuration

--- a/src/ugrd/initramfs_generator.py
+++ b/src/ugrd/initramfs_generator.py
@@ -124,6 +124,7 @@ class InitramfsGenerator(GeneratorHelpers):
 
             if isinstance(function_output, str) and "\n" in function_output:
                 from textwrap import dedent
+
                 function_output = dedent(function_output)
                 function_output = [  # If the output string has a newline, split and get rid of empty lines
                     line for line in function_output.split("\n") if line and line != "\n" and not line.isspace()
@@ -147,16 +148,100 @@ class InitramfsGenerator(GeneratorHelpers):
         else:
             self.logger.debug("[%s] Function returned no output" % function.__name__)
 
+    def sort_hook_functions(self, hook: str) -> None:
+        """Sorts the functions for the specified hook based on the import order.
+        "before" functions are moved before the target function,
+        "after" functions' target function is moved before the current function.
+
+        Filters orders which do not contain functions or targets in the current hook.
+        """
+        func_names = [func.__name__ for func in self["imports"].get(hook, [])]
+        if not func_names:
+            return self.logger.debug("No functions for hook: %s" % hook)
+
+        b = self["import_order"].get("before", {})
+        before = {k: v for k, v in b.items() if k in func_names and any(subv in func_names for subv in b[k])}
+        a = self["import_order"].get("after", {})
+        after = {k: v for k, v in a.items() if k in func_names and any(subv in func_names for subv in a[k])}
+
+        if not before and not after:
+            return self.logger.debug("No import order specified for hook: %s" % hook)
+
+        def iter_order(order, direction):
+            # Iterate over all before/after functions
+            # If the function is not in the correct position, move it
+            # Use the index of the function to determine the position
+            # Move the function in the imports list as well
+            changed = False
+
+            for func_name, other_funcs in order.items():
+                func_index = func_names.index(func_name)
+                assert func_index >= 0, "Function not found in import list: %s" % func_name
+                for other_func in other_funcs:
+                    try:
+                        other_index = func_names.index(other_func)
+                    except ValueError:
+                        continue
+                    assert other_index >= 0, "Function not found in import list: %s" % other_func
+
+                    def reorder_func(direction):
+                        """ Reorders the function based on the direction. """
+                        self.logger.debug("Moving %s %s %s" % (func_name, direction, other_func))
+                        if direction == "before":  # Move the function before the other function
+                            self.logger.debug("[%s] Moving function before: %s" % (func_name, other_func))
+                            func_names.insert(other_index, func_names.pop(func_index))
+                            self["imports"][hook].insert(other_index, self["imports"][hook].pop(func_index))
+                        elif direction == "after":  # Move the other function before the current function
+                            self.logger.debug("[%s] Moving function before: %s" % (other_func, func_name))
+                            func_names.insert(func_index, func_names.pop(other_index))
+                            self["imports"][hook].insert(func_index, self["imports"][hook].pop(other_index))
+                        else:
+                            raise ValueError("Invalid direction: %s" % direction)
+
+                    self.logger.log(5, "[%s] Imports:\n%s", hook, ", ".join(i.__name__ for i in self["imports"][hook]))
+                    if direction == "before":  # func_index should be before other_index
+                        if func_index > other_index:  # If the current function is after the other function
+                            reorder_func("before")  # Move the current function before the other function)
+                            changed = True
+                        else:  # Log otherwise
+                            self.logger.log(5, "Function %s already before: %s" % (func_name, other_func))
+                    elif direction == "after":  # func_index should be after other_index
+                        if func_index < other_index:  # If the current function is before the other function
+                            reorder_func("after")  # Move the current function after the other function
+                            changed = True
+                        else:
+                            self.logger.log(5, "Function %s already after: %s" % (func_name, other_func))
+                    else:
+                        raise ValueError("Invalid direction: %s" % direction)
+            return changed
+
+        max_iterations = len(func_names) * (len(before) + 1) * (len(after) + 1)  # Prevent infinite loops
+        iterations = max_iterations
+        while iterations:
+            iterations -= 1
+            if not any([iter_order(before, "before"), iter_order(after, "after")]):
+                self.logger.debug("[%s] Import order converged after %s iterations" % (hook, max_iterations - iterations))
+                break  # Keep going until no changes are made
+        else:
+            self.logger.error("Import list: %s" % func_names)
+            self.logger.error("Before: %s" % before)
+            self.logger.error("After: %s" % after)
+            raise ValueError("Import order did not converge after %s iterations" % max_iterations)
+
     def run_hook(self, hook: str, *args, **kwargs) -> list[str]:
-        """Runs a hook for imported functions."""
+        """Runs all functions for the specified hook.
+        If the function is masked, it will be skipped.
+        If the function is in import_order, handle the ordering
+        """
+        self.sort_hook_functions(hook)
         out = []
         for function in self["imports"].get(hook, []):
-            # Check that the function is not masked
             if function.__name__ in self["masks"].get(hook, []):
                 self.logger.warning(
                     "[%s] Skipping masked function: %s" % (hook, colorize(function.__name__, "yellow", bold=True))
                 )
                 continue
+
             if function_output := self.run_func(function, *args, **kwargs):
                 out.append(function_output)
         return out

--- a/src/ugrd/initramfs_generator.py
+++ b/src/ugrd/initramfs_generator.py
@@ -22,12 +22,9 @@ class InitramfsGenerator(GeneratorHelpers):
         # init_pre and init_final are run as part of generate_initramfs_main
         self.init_types = [
             "init_debug",
-            "init_early",
             "init_main",
             "init_late",
-            "init_premount",
             "init_mount",
-            "init_mount_late",
             "init_cleanup",
         ]
 

--- a/src/ugrd/initramfs_generator.py
+++ b/src/ugrd/initramfs_generator.py
@@ -291,7 +291,7 @@ class InitramfsGenerator(GeneratorHelpers):
         init.extend(self.run_init_hook("init_pre"))  # Always run init_pre first
 
         # If custom_init is used, create the init using that
-        if self["imports"].get("custom_init") and self.get("_custom_init_file"):
+        if self["imports"].get("custom_init"):
             init += ["\n# !!custom_init"]
             init_line, custom_init = self["imports"]["custom_init"](self)
             if isinstance(init_line, str):
@@ -299,6 +299,7 @@ class InitramfsGenerator(GeneratorHelpers):
             else:
                 init.extend(init_line)
         else:  # Otherwise, use the standard init generator
+            custom_init = None
             init.extend(self.generate_init_main())
 
         init.extend(self.run_init_hook("init_final"))  # Always run init_final last
@@ -308,7 +309,8 @@ class InitramfsGenerator(GeneratorHelpers):
             self._write("/etc/profile", self.generate_profile(), 0o755)
             self.logger.info("Included functions: %s" % ", ".join(list(self.included_functions.keys())))
 
-        if self.get("_custom_init_file"):  # Write the custom init file if it exists
+        # Write the custom init file if it exists
+        if custom_init:
             self._write(self["_custom_init_file"], custom_init, 0o755)
 
         self._write("init", init, 0o755)

--- a/src/ugrd/net/dhcpcd.py
+++ b/src/ugrd/net/dhcpcd.py
@@ -1,0 +1,14 @@
+__version__ = "0.2.1"
+
+
+from zenlib.util import contains
+
+
+@contains("net_device", "net_device must be set", raise_exception=True)
+def init_dhcpcd(self) -> str:
+    """Return shell lines to start dhcpcd"""
+    return f"""
+    net_device=$(resolve_mac {self.net_device_mac})
+    einfo "Starting dhcpcd on: $net_device"
+    einfo "dhcpcd output:\n$(dhcpcd "$net_device" 2>&1)"
+    """

--- a/src/ugrd/net/dhcpcd.toml
+++ b/src/ugrd/net/dhcpcd.toml
@@ -1,4 +1,6 @@
 modules = [ "ugrd.net.net" ]
+provides = "net"
+
 binaries = [ "dhcpcd" ]
 
 [imports.init_pre]

--- a/src/ugrd/net/dhcpcd.toml
+++ b/src/ugrd/net/dhcpcd.toml
@@ -1,0 +1,8 @@
+modules = [ "ugrd.net.net" ]
+binaries = [ "dhcpcd" ]
+
+[imports.init_pre]
+"ugrd.net.dhcpcd" = [ "init_dhcpcd" ]
+
+[import_order.after]
+"init_dhcpcd" = "load_modules"

--- a/src/ugrd/net/net.py
+++ b/src/ugrd/net/net.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from zenlib.util import colorize, contains, unset
 
-from .. import AutodetectError
+from ugrd import AutodetectError
 
 
 def _process_net_device(self, net_device: str):

--- a/src/ugrd/net/net.py
+++ b/src/ugrd/net/net.py
@@ -1,0 +1,74 @@
+__version__ = "0.1.0"
+
+from json import loads
+from pathlib import Path
+
+from zenlib.util import colorize, contains, unset
+
+from .. import AutodetectError
+
+
+def _process_net_device(self, net_device: str):
+    """Sets self.net_device to the given net_device."""
+    _validate_net_device(self, net_device)
+    self.data["net_device"] = net_device
+    self["net_device_mac"] = (Path("/sys/class/net") / net_device / "address").read_text().strip()
+
+
+def _validate_net_device(self, net_device: str):
+    """Validates the given net_device."""
+    if not net_device:  # Ensure the net_device is not empty
+        raise ValueError("net_device must not be empty")
+    dev_path = Path("/sys/class/net") / net_device
+    if not dev_path.exists():  # Ensure the net_device exists on the system
+        self.logger.error("Network devices: %s", ", ".join([dev.name for dev in Path("/sys/class/net").iterdir()]))
+        raise ValueError("Invalid net_device: %s" % net_device)
+    if not (dev_path / "address").exists():
+        raise ValueError("Invalid net_device, missing MAC address: %s" % net_device)
+
+
+@contains("hostonly")
+def autodetect_net_device_kmods(self):
+    """Autodetects the driver for the net_device."""
+    device_path = Path("/sys/class/net") / self["net_device"] / "device"
+    if not device_path.exists():
+        raise AutodetectError("Unable to determine device driver for device: %s" % self["net_device"])
+
+    driver_path = Path("/sys/class/net") / self["net_device"] / "device" / "driver"
+    if driver_path.is_symlink():
+        driver_name = driver_path.resolve().name
+        self.logger.info("Autodetected net_device_driver: %s" % colorize(driver_name, "cyan"))
+        self["kmod_init"] = driver_name
+    else:
+        raise AutodetectError("Unable to determine device driver for device: %s" % self["net_device"])
+
+
+@unset("net_device", log_level=40)
+@contains("hostonly")
+def autodetect_net_device(self):
+    """Sets self.net_device to the device used for the default route with the lowest metric."""
+    routes = loads(self._run(["ip", "-j", "r"]).stdout.decode())
+
+    gateways = {}
+    for route in routes:
+        if route["dst"] == "default":
+            gateways[route["metric"]] = route
+
+    if not gateways:
+        raise AutodetectError("No default route found")
+
+    self["net_device"] = gateways[min(gateways.keys())]["dev"]
+    self.logger.info("Autodetected net_device: %s" % colorize(self["net_device"], "cyan"))
+
+
+def resolve_mac(self):
+    """Returns a shell script to resolve a MAC address to a deviec name"""
+    return """
+    for dev in /sys/class/net/*; do
+        if [ "$(cat $dev/address)" == "$1" ]; then
+            printf "%s" "${dev##*/}"
+            return
+        fi
+    done
+    rd_fail "Unable to resolve MAC address to device name: $1"
+    """

--- a/src/ugrd/net/net.toml
+++ b/src/ugrd/net/net.toml
@@ -1,0 +1,19 @@
+binaries = [ "ip" ]
+
+kmod_ignore_network = false
+
+[imports.config_processing]
+"ugrd.net.net" = [ "_process_net_device" ] 
+
+[imports.functions]
+"ugrd.net.net" = [ "resolve_mac" ]
+
+[imports.build_enum]
+"ugrd.net.net" = [ "autodetect_net_device" ]
+
+[imports.build_pre]
+"ugrd.net.net" = [ "autodetect_net_device_kmods" ]
+
+[custom_parameters]
+net_device = "str"  # The primary network device to use for network operations
+net_device_mac = "str"  # The MAC address of the primary network device

--- a/src/ugrd/net/static.py
+++ b/src/ugrd/net/static.py
@@ -1,0 +1,63 @@
+__version__ = "0.2.0"
+
+from json import loads
+
+from zenlib.util import colorize, contains, unset
+
+from .. import AutodetectError
+
+
+@unset("ip_gateway")
+@contains("autodetect_gateway")
+@contains("hostonly")
+def autodetect_gateway(self):
+    """Detects the default route and sets ip_gateway accordingly.
+    Returns the device name of the default route.
+    """
+    routes = loads(self._run(["ip", "-j", "r"]).stdout.decode())
+
+    for route in routes:
+        if route["dev"] == self["net_device"]:
+            self["ip_gateway"] = route["gateway"]
+            return self.logger.info(
+                "[%s] Detected gateway: %s", colorize(self["net_device"], "blue"), colorize(self["ip_gateway"], "cyan")
+            )
+    else:
+        raise AutodetectError("No default route found")
+
+
+@unset("ip_address")
+@contains("autodetect_ip")
+@contains("hostonly")
+def autodetect_ip(self):
+    """Autodetects the ip address of the network device if not already set."""
+    device_info = loads(self._run(["ip", "-d", "-j", "a", "show", self["net_device"]]).stdout.decode())[0]
+    if "vlan" == device_info.get("linkinfo", {}).get("info_kind"):  # enable the VLAN module to handle vlans
+        self.logger.info("[%s] VLAN detected, enabling the VLAN module.", colorize(self["net_device"], "blue"))
+        self["modules"] = "ugrd.net.vlan"
+    ip_addr = device_info["addr_info"][0]["local"]
+    ip_cidr = device_info["addr_info"][0]["prefixlen"]
+    self["ip_address"] = f"{ip_addr}/{ip_cidr}"
+    self.logger.info(
+        "[%s] Detected ip address: %s", colorize(self["net_device"], "blue"), colorize(self["ip_address"], "cyan")
+    )
+
+
+@contains("ip_address", "ip_address must be set", raise_exception=True)
+@contains("ip_gateway", "ip_gateway must be set", raise_exception=True)
+@contains("net_device", "net_device must be set", raise_exception=True)
+def init_net(self) -> str:
+    """Returns shell lines to initialize the network device.
+    Skips the initialization if the device is already up, and there is a gateway on the device.
+    """
+    return f"""
+    net_device=$(resolve_mac {self.net_device_mac})
+    if ip link show "$net_device" | grep -q 'UP,' && ip route show | grep -q "default via .* dev $net_device"; then
+        ewarn "Network device is already up, skipping: $net_device"
+        return
+    fi
+    einfo "Configuring network device: $net_device"
+    ip link set "$net_device" up
+    ip addr add {self.ip_address} dev "$net_device"
+    ip route add default via {self.ip_gateway}
+    """

--- a/src/ugrd/net/static.toml
+++ b/src/ugrd/net/static.toml
@@ -1,0 +1,21 @@
+modules = [ "ugrd.net.net" ]
+
+autodetect_ip = true
+autodetect_gateway = true
+
+[imports.build_pre]
+"ugrd.net.static" = [ "autodetect_gateway", "autodetect_ip" ]
+
+[imports.init_pre]
+"ugrd.net.static" = [ "init_net" ]
+
+[import_order.after]
+"autodetect_gateway" = "autodetect_net_device"
+"autodetect_ip" = "autodetect_gateway"
+"init_net" = [ "load_modules", "init_dhcpcd" ]
+
+[custom_parameters]
+autodetect_ip = "bool"  # Autodetect IP address from the default gateway
+autodetect_gateway = "bool"  # Autodetect default gateway from the IP address
+ip_address = "str"  # IP address to use for the static configuration, with cidr
+ip_gateway = "str"  # Default gateway to set

--- a/src/ugrd/net/static.toml
+++ b/src/ugrd/net/static.toml
@@ -1,4 +1,5 @@
 modules = [ "ugrd.net.net" ]
+provides = "net"
 
 autodetect_ip = true
 autodetect_gateway = true

--- a/src/ugrd/net/vlan.toml
+++ b/src/ugrd/net/vlan.toml
@@ -1,0 +1,2 @@
+modules = [ "ugrd.net.net" ]
+


### PR DESCRIPTION
Improve code consistency (var naming, imports)
Add before/after hook implementation
implement better function ordering throughout
remove init_early, init_premount, init_late, init_mount_late, init_cleanup runlevels
Add provides/needs system
Add net, compat modules
Allow _write helper to append to files
Use /run/ugrd instead of /run/vars for runtime variables
clear /run/ugrd before switch_root
Always execute commands in log statements, even if not logged.
Don't add the console nodes by default, use compat module can be used if needed.
Add internal devpts mount option which can be toggled
Improve switch_root init_target flow
auto-enable fakeudev if systemd is detected as the init
