### PR TITLE
Update resume.toml to support encrypted swap.

### DIFF
--- a/src/ugrd/fs/resume.toml
+++ b/src/ugrd/fs/resume.toml
@@ -3,5 +3,5 @@ cmdline_strings = [ "resume" ]
 [imports.init_main] 
 "ugrd.fs.resume" = [ "handle_resume" ]
 
-[import_order.before]
-handle_resume = "mount_fstab"
+[import_order.after]
+handle_resume = "crypt_init"


### PR DESCRIPTION
Swap partition must be decrypted before trying resume.

