### PR TITLE
Resume

### DIFF
--- a/src/ugrd/fs/mdraid.py
+++ b/src/ugrd/fs/mdraid.py
@@ -1,5 +1,8 @@
-__version__ = '0.1.2'
+__version__ = '0.2.0'
 
 
 def md_init(self):
-    return 'einfo "Assembling MD devices: $(mdadm --assemble --scan 2>&1)"'
+    return """
+    export MDADM_NO_UDEV=1
+    einfo "Assembling MD devices: $(mdadm --assemble --scan 2>&1)"
+    """


### PR DESCRIPTION
update 043f5ab : Update resume.py to handle also UUID= and LABEL= among PARTUUID=
which is already in main
update c9a8cf7 : Update tell mdadm not to use UDEV by exporting MDADM_NO_UDEV