### PR TITLE
namespace cmdline args when necessary

### DIFF
--- a/docs/runtime_usage.md
+++ b/docs/runtime_usage.md
@@ -10,4 +10,6 @@
 
 In the event of a failure, modules will either fail through, or re-exec the init script.
 
-The `recovery` cmdline arg will allow a shell to be spawned in the event of a failure. This is useful for debugging.
+The `ugrd_recovery` cmdline arg will allow a shell to be spawned in the event of a failure. This is useful for debugging.
+
+> This can be set by simply adding `ugrd_recovery` to the kernel command line, or `ugrd_recovery=1`

--- a/src/ugrd/base/base.py
+++ b/src/ugrd/base/base.py
@@ -166,7 +166,7 @@ def rd_fail(self) -> list[str]:
         r'eerror "Loaded modules:\n$(cat /proc/modules)"',
         r'eerror "Block devices:\n$(blkid)"',
         r'eerror "Mounts:\n$(mount)"',
-        'if [ "$(readvar recovery)" = "1" ]; then',
+        'if [ "$(readvar ugrd_recovery)" = "1" ]; then',
         '    einfo "Entering recovery shell"',
     ]
     if "ugrd.base.plymouth" in self["modules"]:
@@ -189,7 +189,7 @@ def rd_fail(self) -> list[str]:
 def setvar(self) -> str:
     """Returns a shell function that sets a variable in /run/ugrd/{name}."""
     return """
-    if check_var debug; then
+    if check_var ugrd_debug; then
         edebug "Setting $1 to $2"
     fi
     printf "%s" "$2" > "/run/ugrd/${1}"
@@ -314,7 +314,7 @@ def edebug(self) -> str:
     if check_var quiet; then
         return
     fi
-    if [ "$(readvar debug)" != "1" ]; then
+    if [ "$(readvar ugrd_debug)" != "1" ]; then
         return
     fi
     printf "\033[1;34m *\033[0m %b\n" "${output}"

--- a/src/ugrd/base/bell.py
+++ b/src/ugrd/base/bell.py
@@ -1,11 +1,11 @@
 __author__ = "desultory"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def startup_bell(self) -> str:
     """ Prints the bell symbol if the bell var is set """
     return """
-    if check_var bell; then
+    if check_var ugrd_bell; then
         printf '\a'
     fi
     """
@@ -13,11 +13,11 @@ def startup_bell(self) -> str:
 def end_bell(self) -> str:
     """ Prints the bell symbol twice if the bell var is set """
     return """
-    if check_var bell; then
+    if check_var ugrd_bell; then
         printf '\a\a'
     fi
     """
 
 def export_bell(self) -> None:
     """ Adds the bell variable to the exports dict """
-    self["exports"]["bell"] = 1 if self["bell"] else 0
+    self["exports"]["ugrd_bell"] = 1 if self["bell"] else 0

--- a/src/ugrd/base/bell.toml
+++ b/src/ugrd/base/bell.toml
@@ -1,4 +1,4 @@
-cmdline_bools = ["bell"]
+cmdline_bools = ["ugrd_bell"]
 
 bell = true
 

--- a/src/ugrd/base/cmdline.toml
+++ b/src/ugrd/base/cmdline.toml
@@ -1,6 +1,11 @@
-cmdline_bools = ['quiet', 'debug', 'recovery']
+cmdline_bools = ['quiet', 'ugrd_debug', 'ugrd_recovery']
 cmdline_strings = ['init', 'loglevel']
 
+# Ensure all cmdline arguments but ones the kernel expects the initramfs to handle are namespaced
+_non_namespaced_cmdline_args = ["init", "resume", "root", "rootdelay", "rootflags", "roottype", "quiet", "loglevel"]
+
+[imports.config_processing]
+"ugrd.base.cmdline" = ["_process__non_namespaced_cmdline_args", "_process_cmdline_bools_multi", "_process_cmdline_strings_multi"]
 
 [imports.init_pre]
 "ugrd.base.cmdline" = [ "export_exports", "parse_cmdline" ]
@@ -13,7 +18,7 @@ export_exports = "make_run_dirs"
 parse_cmdline = "export_exports"
 
 [custom_parameters]
+_non_namespaced_cmdline_args = "NoDupFlatList" # set the non-namespaced cmdline args to be procesed from /proc/cmdline
 exports = "dict"  # Add the exports property, used to specify the exports for the init script
 cmdline_bools = "NoDupFlatList" # set the booleans to be procesed from /proc/cmdline
 cmdline_strings = "NoDupFlatList" # set the strings to be procesed from /proc/cmdline
-_init_mount = "NoDupFlatList" # List contaning functions which were removed from imports.int_mount by refactor_mounts

--- a/src/ugrd/base/debug.py
+++ b/src/ugrd/base/debug.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from os import environ
 from pathlib import Path
@@ -42,8 +42,8 @@ def _validate_editor(self, editor: str):
 def start_shell(self) -> str:
     """Start a shell at the start of the initramfs."""
     return """
-    if ! check_var debug; then
-        ewarn "The debug module is enabled, but debug is not set enabled"
+    if ! check_var ugrd_debug; then
+        ewarn "The ugrd.base.debug module is enabled, but ugrd_debug is not enabled!"
         return
     fi
     einfo "Starting debug shell"
@@ -54,4 +54,4 @@ def start_shell(self) -> str:
 @contains("start_shell", "Not enabling the debug shell, as the start_shell option is not set.", log_level=30)
 def enable_debug(self) -> str:
     """Enable debug mode."""
-    return "setvar debug 1"
+    return "setvar ugrd_debug 1"

--- a/src/ugrd/fs/ext4.py
+++ b/src/ugrd/fs/ext4.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from zenlib.util import unset
 
@@ -8,8 +8,8 @@ def ext4_fsck(self) -> str:
     """Returns a shell function to run fsck on the root filesystem
     The root device is determined by checking the source of SWITCH_ROOT_TARGET"""
     return """
-    if check_var no_fsck; then
-        ewarn 'no_fsck is set, skipping fsck'
+    if check_var ugrd_no_fsck; then
+        ewarn 'ugrd_no_fsck is set, skipping fsck'
         return
     fi
     ROOT_DEV=$(awk -v target="$(readvar SWITCH_ROOT_TARGET)" '$2 == target {{print $1}}' /proc/mounts)

--- a/src/ugrd/fs/f2fs.py
+++ b/src/ugrd/fs/f2fs.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from zenlib.util import unset
 
@@ -8,8 +8,8 @@ def f2fs_fsck(self) -> str:
     """Returns a shell function to run fsck on the root filesystem
     The root device is determined by checking the source of SWITCH_ROOT_TARGET"""
     return """
-    if check_var no_fsck; then
-        ewarn 'no_fsck is set, skipping fsck'
+    if check_var ugrd_no_fsck; then
+        ewarn 'ugrd_no_fsck is set, skipping fsck'
         return
     fi
     ROOT_DEV=$(awk -v target="$(readvar SWITCH_ROOT_TARGET)" '$2 == target {{print $1}}' /proc/mounts)

--- a/src/ugrd/fs/livecd.py
+++ b/src/ugrd/fs/livecd.py
@@ -14,9 +14,9 @@ def mount_livecd(self) -> str:
     All mount handling happens strictly at runtime
     """
     return f"""
-    livecd_label="$(readvar livecd_label)"
+    livecd_label="$(readvar ugrd_livecd_label)"
     if [ -z "$livecd_label" ]; then
-        rd_fail "livecd_label must be set to the label of the livecd storage root."
+        rd_fail "ugrd_livecd_label must be set to the label of the livecd storage root."
     fi
     einfo "Mounting livecd with label: $livecd_label"
     while ! mount LABEL="$livecd_label" /run/livecd 2>/dev/null; do
@@ -44,7 +44,7 @@ def set_livecd_mount(self):
             "no_validate": True,
         }
     }
-    self["exports"]["livecd_label"] = self.livecd_label
+    self["exports"]["ugrd_livecd_label"] = self.livecd_label
 
 
 def set_squashfs_root_source(self) -> str:

--- a/src/ugrd/fs/livecd.toml
+++ b/src/ugrd/fs/livecd.toml
@@ -1,6 +1,6 @@
 modules = ["ugrd.fs.overlayfs"]
 
-cmdline_strings = [ "livecd_label", "squashfs_image" ]
+cmdline_strings = [ "ugrd_livecd_label", "ugrd_squashfs_image" ]
 
 squashfs_image = 'image.squashfs'
 hostonly = false

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -10,7 +10,7 @@ binaries = [
 provides = "mounts" 
 
 cmdline_strings =  ["root", "roottype", "rootflags", "rootdelay" ]
-cmdline_bools = ["no_fsck"]
+cmdline_bools = ["ugrd_no_fsck"]
 
 run_dirs = [ "ugrd" ]
 


### PR DESCRIPTION
certain cmdline args such as "debug" should never be handled by userspace systems. Others, such as "resume" "root", or "init" related ones must be handled by the initramfs, unless they are ignored entirely.

Checks that vars defined in the build process have namespaces unless specific exclusions are defined.