### PR TITLE
move test_copy_config into the base config dict

### DIFF
--- a/src/ugrd/base/test.toml
+++ b/src/ugrd/base/test.toml
@@ -25,7 +25,6 @@ test_arch = "str"  # Define the qemu arch (added to the qemu-system- command)
 test_cmdline = "str"  # Define the kernel command line for the test image
 test_timeout = "int"  # Define the timeout for the test
 test_image_size = "int"  # Define the size of the test image, in MB
-test_copy_config = "NoDupFlatList"  # Config parameters to copy into the image builder
 test_flag = "str"  # Define the success flag for the test
 test_rootfs_name = "str"  # Define the name of the rootfs image
 test_rootfs_build_dir = "Path"  # Define the build directory for the rootfs image

--- a/src/ugrd/initramfs_dict.py
+++ b/src/ugrd/initramfs_dict.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "2.3.5"
+__version__ = "2.4.0"
 
 from collections import UserDict
 from importlib import import_module
@@ -39,8 +39,9 @@ class InitramfsConfigDict(UserDict):
         "validated": bool,  # A flag to indicate if the config has been validated, mostly used for log levels
         "custom_parameters": dict,  # Custom parameters loaded from imports
         "custom_processing": dict,  # Custom processing functions which will be run to validate and process parameters
-        "_processing": dict,
-    }  # A dict of queues containing parameters which have been set before the type was known
+        "_processing": dict, # A dict of queues containing parameters which have been set before the type was known
+        "test_copy_config": NoDupFlatList,  # A list of config values which are copied into test images, from the parent
+    }
 
     def __init__(self, NO_BASE=False, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This prevents errors when modules have this defined, but the test module is not loaded.