### PR TITLE
don't use rootdelay for mount timeout, add ugrd_mount_timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,7 +283,7 @@ This module handles CPIO creation.
 
 These are set at the global level and are not associated with an individual mount:
 
-* `mount_timeout` (1.0) - Timeout in seconds for mount retries, can be set with `rootdelay` in the kernel command line.
+* `mount_timeout` (1.0) - Timeout in seconds for mount retries, can be set with in the kernel command line with `ugrd_mount_timeout`.
 * `mount_retries` - Number of times to retry running `mount -a`, no limit if unset.
 
 #### ugrd.fs.btrfs

--- a/src/ugrd/fs/mounts.toml
+++ b/src/ugrd/fs/mounts.toml
@@ -2,7 +2,7 @@ binaries = [ "lsblk", "blkid", "mount", "umount", "mkdir" ]
 
 provides = "mounts" 
 
-cmdline_strings =  ["root", "roottype", "rootflags", "rootdelay" ]
+cmdline_strings =  ["root", "roottype", "rootflags", "ugrd_mount_timeout" ]
 cmdline_bools = ["ugrd_no_fsck"]
 
 run_dirs = [ "ugrd" ]


### PR DESCRIPTION
don't misuse this kernel arg, add a namespaced arg that corresponds to internal config