### PR TITLE
BUGFIX: Fix odd subshell behaviour if device is not first detected

### DIFF
--- a/src/ugrd/crypto/cryptsetup.py
+++ b/src/ugrd/crypto/cryptsetup.py
@@ -448,9 +448,6 @@ def get_crypt_dev(self) -> str:
             printf "%s" "$source_dev"
         fi
     fi
-    if [ -z "$source_dev" ]; then
-        rd_fail "Failed to find cryptsetup device: $1"
-    fi
     """
 
 
@@ -462,6 +459,10 @@ def open_crypt_dev(self) -> str:
     """
     out = """
     crypt_device="$(get_crypt_dev "$1")"
+    if [ -z "$crypt_device" ]; then
+        rd_fail "Failed to find cryptsetup device: $1"
+    fi
+
     header="$(readvar CRYPTSETUP_HEADER_"$1")"
 
     cryptsetup_args="cryptsetup open --tries 1"


### PR DESCRIPTION
As discussed on discord.

get_crypt_device started a subshell and ran a new init, swallowing logs and input and causing other spookiness.

Just edited on github for the moment as it is so simple, but I will do due diligence and clone the repo properly asap.