### PR TITLE
improve check_in_file and warning for empty initramfs fstab

### DIFF
--- a/src/ugrd/base/checks.py
+++ b/src/ugrd/base/checks.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from pathlib import Path
 
@@ -31,8 +31,11 @@ def _check_in_file(self, file, lines):
     with open(file, "r") as f:
         file_lines = f.readlines()
 
+    stripped_lines = [line.strip() for line in file_lines]
+
     for check_line in lines:
-        if check_line not in file_lines:
+        if check_line not in file_lines and check_line not in stripped_lines:
+            self.logger.info(f"File lines: {file_lines}")
             raise ValueError("Failed to find line '%s' in file '%s'" % (check_line, file))
 
 

--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "7.1.1"
+__version__ = "7.1.2"
 
 from pathlib import Path
 from re import search
@@ -294,7 +294,9 @@ def _to_fstab_entry(self, mount: dict) -> str:
 
 
 def generate_fstab(self, mount_class="mounts", filename="/etc/fstab") -> None:
-    """Generates the fstab from the specified mounts."""
+    """Generates the fstab from the specified mounts.
+    Adds fstab entries to the check_in_file, to ensure they exist in the final image.
+    """
     fstab_info = [f"# UGRD Filesystem module v{__version__}"]
 
     for mount_name, mount_info in self[mount_class].items():
@@ -308,6 +310,7 @@ def generate_fstab(self, mount_class="mounts", filename="/etc/fstab") -> None:
 
     if len(fstab_info) > 1:
         self._write(filename, fstab_info)
+        self["check_in_file"][filename] = fstab_info
     else:
         self.logger.debug(
             "[%s] No fstab entries generated for mounts: %s" % (mount_class, ", ".join(self[mount_class].keys()))
@@ -865,7 +868,7 @@ def mount_fstab(self) -> list[str]:
     mount_retries sets the number of times to retry the mount, infinite otherwise.
     """
     if not self._get_build_path("/etc/fstab").exists():
-        return self.logger.warning("No initramfs fstab found, skipping mount_fstab.")
+        return self.logger.info("No initramfs fstab found, skipping mount_fstab. If non-root storage devices are not needed at boot, this is fine.")
 
     out = [
         'einfo "Attempting to mount all filesystems."',


### PR DESCRIPTION
the warning was confusing, this also ensures that the fstab is double checked, in case a module clobbers it