### PR TITLE
add kmod_init_optional, move some USB modules there

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,7 @@ The following parameters can be used to change the kernel module pulling and ini
 * `kernel_version` (uname -r) Used to specify the kernel version to pull modules for, should be a directory under `/lib/modules/<kernel_version>`.
 * `kmod_pull_firmware` (true) Adds kernel module firmware to dependencies
 * `kmod_init` - Kernel modules to `modprobe` at boot.
+* `kmod_init_optional` - Modules to attempt to add to `kmod_init`, failing with a warning if not found.
 * `kmod_autodetect_lspci` (false) Finds kernel modules for PCI devices using `/sys/bus/pci/drivers`, formely used `lspci -k`.
 * `kmod_autodetect_lsmod` (false) Pulls kernel modules using `/proc/modules`, formerly used `lsmod`.
 * `kernel_modules` - Kernel modules to pull into the initramfs. These modules will not be `modprobe`'d automatically.

--- a/src/ugrd/kmod/kmod.toml
+++ b/src/ugrd/kmod/kmod.toml
@@ -20,6 +20,7 @@ kmod_autodetect_lsmod = "bool"  # Whether or not to automatically pull currently
 kmod_autodetect_lspci = "bool"  # Whether or not to automatically pull kernel modules from lspci -k
 kernel_modules = "NoDupFlatList"  # Kernel modules to pull into the initramfs
 kmod_init = "NoDupFlatList"  # Kernel modules to load at initramfs startup
+kmod_init_optional = "NoDupFlatList"  # Kernel modules to try to add to kmod_init
 no_kmod = "bool" # Disables kernel modules entirely
 
 [imports.config_processing]

--- a/src/ugrd/kmod/usb.toml
+++ b/src/ugrd/kmod/usb.toml
@@ -1,1 +1,2 @@
-kmod_init = ['uas', 'usbcore', 'scsi_mod', 'ehci_hcd', 'ohci_hcd', 'uhci_hcd', 'xhci_hcd']
+kmod_init = ['uas', 'usbcore']
+kmod_init_optional = ['ehci_hcd', 'ohci_hcd', 'uhci_hcd', 'xhci_hcd']


### PR DESCRIPTION
_kmod_auto was used for modules which may or may not be found, this is somewhat confusing. this config option should be used for things which may or may not be needed.