### PR TITLE
fakeudev: change `source` to `.` for compatibility with POSIX shells

### DIFF
--- a/src/ugrd/fs/fakeudev.py
+++ b/src/ugrd/fs/fakeudev.py
@@ -16,7 +16,7 @@ def fake_dm_udev(self) -> str:
         if [ ! -e "${dm}/uevent" ]; then
             continue
         fi
-        source "${dm}/uevent"
+        . "${dm}/uevent"
         einfo "Faking udev for: ${DEVNAME}"
         udev_db_file="/run/udev/data/b${MAJOR}:${MINOR}"
         printf 'E:DM_UDEV_PRIMARY_SOURCE_FLAG=1\n' > "${udev_db_file}"


### PR DESCRIPTION
When using the `ugrd.fs.fakeudev` module, my boot hangs after the following message:

```
/init: 377: source: not found
```
Which I found was caused by this line in the generated `/etc/profile`:

https://github.com/desultory/ugrd/blob/37c4bedb4200e66bf11ccc0e4614b27aabae1d57/src/ugrd/fs/fakeudev.py#L19

I am on Gentoo Linux with `/bin/sh` symlinked to `dash` - which does not have the `source` builtin. I have changed this to use the `.` builtin to be compatible with all POSIX shells.