### PR TITLE
re-add console node definition

### DIFF
--- a/src/ugrd/base/compat.toml
+++ b/src/ugrd/base/compat.toml
@@ -1,4 +1,0 @@
-[nodes.console]
-mode = 0o644
-major = 5
-minor = 1

--- a/src/ugrd/base/core.toml
+++ b/src/ugrd/base/core.toml
@@ -13,6 +13,11 @@ binary_search_paths = [ "/bin", "/sbin", "/usr/bin", "/usr/sbin" ]
 old_count = 1
 timeout = 15
 
+[nodes.console]
+mode = 0o644
+major = 5
+minor = 1
+
 [imports.config_processing]
 "ugrd.base.core" = [ "_process_build_logging",
 		     "_process_out_file",


### PR DESCRIPTION
this seems to be required for initarmfs images which are embedded into the kernel using CONFIG_EXTRA_FIRMWARE