### PR TITLE
fix fs.fakeudev, do not source uevent file

### DIFF
--- a/src/ugrd/fs/fakeudev.py
+++ b/src/ugrd/fs/fakeudev.py
@@ -13,12 +13,16 @@ def fake_dm_udev(self) -> str:
     """returns a shell function to fake udev for dm devices."""
     return r"""
     for dm in /sys/block/dm-*; do
-        if [ ! -e "${dm}/uevent" ]; then
+        if [ ! -e "${dm}/dev" ]; then
             continue
         fi
-        . "${dm}/uevent"
-        einfo "Faking udev for: ${DEVNAME}"
-        udev_db_file="/run/udev/data/b${MAJOR}:${MINOR}"
+        if [ ! -e "${dm}/dm/name" ]; then
+            continue
+        fi
+        dev_name=$(cat ${dm}/dm/name)
+        majmin=$(cat "${dm}/dev")
+        einfo "Faking udev for: ${dev_name}"
+        udev_db_file="/run/udev/data/b${majmin}"
         printf 'E:DM_UDEV_PRIMARY_SOURCE_FLAG=1\n' > "${udev_db_file}"
     done
     """


### PR DESCRIPTION
My image throws a kernel panic:

```
* Running fsck on: /dev/mapper/luksvg-gentoo
/dev/mapper/luksvg-gentoo: clean, 635733/20721152 files, 6987471/114859008 blocks
/etc/profile: line 420: /sys/block/dm-0/uevent: Success
[   10.201899] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
[   10.203771] CPU: 0 PID: 1 Comm: init Not tainted 6.12.34-gentoo-dist #1
```

The problem is sourcing the `uevent` file. I'm not exactly sure how it crashed the init but it doesn't seem we have to read from there.

Also, I could disable `fake_dm_udev`, by commenting the line in `init` file, and my systemd system booted just fine. Not sure if #181 was necessary.

My setup:
> Ext4 rootfs partition on LVM and LVM on LUKS.
> Systemd 257.7

I haven't changed default config and ugrd was able to detect LUKS and LVM automatically, great job :)