### PR TITLE
add toggle to disable normalization of kmod names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,6 +178,7 @@ The following parameters can be used to change the kernel module pulling and ini
 * `kmod_ignore` - Kernel modules to ignore. Modules which depend on ignored modules will also be ignored.
 * `kmod_ignore_softdeps` (false) Ignore softdeps when checking kernel module dependencies.
 * `no_kmod` (false) Disable kernel modules entirely.
+* `kmod_no_normalize` - A list of kernel module names to not normalize (replace dashes with underscores).
 
 ##### ugrd.kmod.input
 

--- a/src/ugrd/kmod/__init__.py
+++ b/src/ugrd/kmod/__init__.py
@@ -1,13 +1,3 @@
-from typing import Union
-
-
-def _normalize_kmod_name(module: Union[str, list]) -> str:
-    """Replaces -'s with _'s in a kernel module name."""
-    if isinstance(module, list) and not isinstance(module, str):
-        return [_normalize_kmod_name(m) for m in module]
-    return module.replace("-", "_")
-
-
 class DependencyResolutionError(Exception):
     pass
 

--- a/src/ugrd/kmod/kmod.toml
+++ b/src/ugrd/kmod/kmod.toml
@@ -22,6 +22,7 @@ kernel_modules = "NoDupFlatList"  # Kernel modules to pull into the initramfs
 kmod_init = "NoDupFlatList"  # Kernel modules to load at initramfs startup
 kmod_init_optional = "NoDupFlatList"  # Kernel modules to try to add to kmod_init
 no_kmod = "bool" # Disables kernel modules entirely
+kmod_no_normalize = "NoDupFlatList" # Kernel modules to not normalize (i.e. not convert dashes to underscores)
 
 [imports.config_processing]
 "ugrd.kmod.kmod" = [ "_process_kernel_version",


### PR DESCRIPTION
in some cases, such as for apple-bce, it seems it can't be queried by the name with an underscore