### PR TITLE
add basic vm platform detection

### DIFF
--- a/src/ugrd/fs/mounts.py
+++ b/src/ugrd/fs/mounts.py
@@ -1,5 +1,5 @@
 __author__ = "desultory"
-__version__ = "7.1.3"
+__version__ = "7.1.4"
 
 from pathlib import Path
 from re import search
@@ -1070,6 +1070,9 @@ def resolve_blkdev_kmod(self, device) -> list[str]:
         kmods.append("virtio_blk")
     elif device_name.startswith("sd"):
         kmods.append("sd_mod")
+        if self["virtual_machine"]:
+            self.logger.info(f"Auto-enabling virtio_scsi for virtual machine block device: {c_(device_name, 'cyan')}")
+            kmods.append("virtio_scsi")
     elif device_name.startswith("mmcblk"):
         kmods.append("mmc_block")
     elif device_name.startswith("sr"):

--- a/src/ugrd/kmod/kmod.toml
+++ b/src/ugrd/kmod/kmod.toml
@@ -1,4 +1,4 @@
-modules = [ "ugrd.kmod.standard_mask", "ugrd.kmod.input" ]
+modules = [ "ugrd.kmod.standard_mask", "ugrd.kmod.platform", "ugrd.kmod.input" ]
 
 binaries = [ "modprobe" ]
 

--- a/src/ugrd/kmod/platform.py
+++ b/src/ugrd/kmod/platform.py
@@ -1,0 +1,45 @@
+from zenlib.util import colorize as c_
+from zenlib.util import contains, unset
+
+__version__ = "0.1.0"
+
+VM_PRODUCT_NAMES = {
+    "Virtual Machine": ["virtio_blk"],
+    "Parallels ARM Virtual Machine": ["virtio_blk"],
+    "Standard PC (Q35 + ICH9, 2009)": ["virtio_blk"],
+}
+
+VM_VENDOR_NAMES = {
+    "Microsoft Corporation": ["hv_storvsc"],
+    "VMware, Inc.": ["vmw_pvscsi"],
+    "Xen": ["xen_blk"],
+    "QEMU": ["virtio_blk"],
+    "Parallels International GmbH.": ["virtio_blk"],
+}
+
+
+@contains("hostonly", "hostonly is not enabled, skipping platform detection.", log_level=30)
+def get_platform_info(self):
+    """Detects plaform information such as the vendor and product name"""
+    with open("/sys/class/dmi/id/product_name", "r") as f:
+        self["_dmi_product_name"] = f.read().strip()
+
+    with open("/sys/class/dmi/id/sys_vendor", "r") as f:
+        self["_dmi_system_vendor"] = f.read().strip()
+
+
+@unset("virtual_machine", "virtual_machine is already set, skipping VM detection.", log_level=10)
+@contains("hostonly", "hostonly is not enabled, skipping VM detection.", log_level=30)
+def autodetect_virtual_machine(self):
+    """Detects if the system is running in a virtual machine, adds relevant kernel modules to the list.
+    Sets the `virtual_machine` attribute to True if a VM is detected, to be used by other modules.
+    """
+    kmods = set()
+    kmods.update(VM_PRODUCT_NAMES.get(self["_dmi_product_name"], []))
+    kmods.update(VM_VENDOR_NAMES.get(self["_dmi_system_vendor"], []))
+
+    if kmods:
+        self.logger.info(
+            f"[{c_(self['_dmi_system_vendor'], color='cyan', bold=True)}]({c_(self['_dmi_product_name'], color='cyan', bright=True)}) Detected VM kmods: {c_((' ').join(kmods), color='magenta', bright=True)}"
+        )
+        self["virtual_machine"] = True

--- a/src/ugrd/kmod/platform.py
+++ b/src/ugrd/kmod/platform.py
@@ -1,5 +1,5 @@
 from zenlib.util import colorize as c_
-from zenlib.util import contains, unset
+from zenlib.util import contains
 
 __version__ = "0.1.0"
 
@@ -28,7 +28,6 @@ def get_platform_info(self):
         self["_dmi_system_vendor"] = f.read().strip()
 
 
-@unset("virtual_machine", "virtual_machine is already set, skipping VM detection.", log_level=10)
 @contains("hostonly", "hostonly is not enabled, skipping VM detection.", log_level=30)
 def autodetect_virtual_machine(self):
     """Detects if the system is running in a virtual machine, adds relevant kernel modules to the list.

--- a/src/ugrd/kmod/platform.toml
+++ b/src/ugrd/kmod/platform.toml
@@ -1,0 +1,11 @@
+[imports.build_enum]
+"ugrd.kmod.platform" = ["get_platform_info", "autodetect_virtual_machine"]
+
+[import_order.before]
+"get_platform_info" = "autodetect_virtual_machine"
+"autodetect_virtual_machine" = "autodetect_root"
+
+[custom_parameters]
+_dmi_product_name = "str"  # /sys/class/dmi/id/product_name
+_dmi_system_vendor = "str"  # /sys/class/dmi/id/sys_vendor
+virtual_machine = "bool"  # Boolean to indicate if the instance is a virtual machine

--- a/src/ugrd/kmod/vm.toml
+++ b/src/ugrd/kmod/vm.toml
@@ -1,2 +1,0 @@
-# This is deprecated, unless required for non-root mounts, in which case it is better to just specify this within the main config
-kmod_init = ['virtio_blk']


### PR DESCRIPTION
ensures necessary drivers are added depending on the vm platform

add a `virtual_machine` var so modules can act accordingly. Make the mounts scsi driver detection consider this and add virtio_scsi