### PR TITLE
make the banner print "built for kernel version"

### DIFF
--- a/src/ugrd/base/banner.py
+++ b/src/ugrd/base/banner.py
@@ -1,10 +1,10 @@
 __author__ = "desultory"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 def print_banner(self) -> list[str]:
     """Prints the banner. Prints the kernel version if set"""
     banner = [self.banner]
     if kver := self.get("kernel_version"):
-        banner.append(f"einfo 'Kernel version: {kver}'")
+        banner.append(f"einfo 'Built for kernel version: {kver}'")
     return banner


### PR DESCRIPTION
printing "kernel version" for the kver used at build time is confusing