### PR TITLE
Fix ldconfig output decoding to tolerate non-UTF-8 bytes and prevent UnicodeDecodeError during libgcc autodetection.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,48 @@ jobs:
         sudo venv/bin/ugrd -d
         sudo venv/bin/python -m unittest discover tests -v
 
+  ubuntu-locale:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Obtain dependency projects
+      run: |
+        git clone https://github.com/desultory/zenlib
+        git clone https://github.com/desultory/pycpio
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install system deps
+      run: |
+        sudo apt update
+        sudo apt install -y pax-utils qemu-system-x86 locales
+    - name: Install python deps
+      run: |
+        python -m venv venv
+        venv/bin/pip install --upgrade pip
+        venv/bin/pip install ./zenlib
+        venv/bin/pip install zstandard
+        venv/bin/pip install ./pycpio
+        venv/bin/pip install .
+    - name: Generate ISO-8859-1 locale
+      run: |
+        sudo locale-gen es_ES.ISO-8859-1
+        locale -a | grep -i '^es_ES'
+    - name: Test fullauto.toml with ISO-8859-1 locale
+      run: |
+        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/python - <<'PY'
+        import locale
+
+        assert locale.getpreferredencoding(False).lower() in {"iso-8859-1", "iso8859-1"}
+        PY
+        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/ugrd -d
+        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/python -m unittest discover tests -v
+
   ubuntu-ksh:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,17 +113,17 @@ jobs:
         venv/bin/pip install .
     - name: Generate ISO-8859-1 locale
       run: |
-        sudo locale-gen es_ES.ISO-8859-1
+        sudo locale-gen es_ES
         locale -a | grep -i '^es_ES'
     - name: Test fullauto.toml with ISO-8859-1 locale
       run: |
-        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/python - <<'PY'
+        sudo env LANG=es_ES LC_ALL=es_ES PYTHONUTF8=0 venv/bin/python - <<'PY'
         import locale
 
         assert locale.getpreferredencoding(False).lower() in {"iso-8859-1", "iso8859-1"}
         PY
-        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/ugrd -d
-        sudo env LANG=es_ES.ISO-8859-1 LC_ALL=es_ES.ISO-8859-1 PYTHONUTF8=0 venv/bin/python -m unittest discover tests -v
+        sudo env LANG=es_ES LC_ALL=es_ES PYTHONUTF8=0 venv/bin/ugrd -d
+        sudo env LANG=es_ES LC_ALL=es_ES PYTHONUTF8=0 venv/bin/python -m unittest discover tests -v
 
   ubuntu-ksh:
     runs-on: ubuntu-latest

--- a/src/ugrd/base/core.py
+++ b/src/ugrd/base/core.py
@@ -1,7 +1,7 @@
 __author__ = "desultory"
 __version__ = "4.8.0"
 
-from os import environ, makedev, mknod, uname
+from os import environ, fsdecode, makedev, mknod, uname
 from pathlib import Path
 from shutil import rmtree, which
 from stat import S_IFCHR
@@ -351,10 +351,11 @@ def _get_ldconfig(self) -> list:
         raise LDConfigError("ldconfig -p not supported, musl libc is likely in use.")
 
     if cmd.returncode != 0:
-        raise LDConfigError("ldconfig failed to run: %s" % cmd.stderr.decode("utf-8"))
+        raise LDConfigError("ldconfig failed to run: %s" % fsdecode(cmd.stderr))
 
-    self.logger.log(5, "ldconfig -p output:\n%s" % cmd.stdout.decode())
-    return cmd.stdout.decode().splitlines()
+    ldconfig_output = fsdecode(cmd.stdout)
+    self.logger.log(5, "ldconfig -p output:\n%s" % ldconfig_output)
+    return ldconfig_output.splitlines()
 
 
 @unset("musl_libc", "Skipping libgcc_s dependency resolution, musl_libc is enabled.", log_level=20)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,31 @@
+from os import fsdecode
+from subprocess import CompletedProcess
+from unittest import TestCase, main
+from unittest.mock import Mock
+
+from ugrd.base.core import LDConfigError, _get_ldconfig
+
+
+class TestCore(TestCase):
+    def test_get_ldconfig_handles_non_utf8_stdout(self):
+        """Ensure ldconfig output with arbitrary path bytes does not crash decoding."""
+        cmd = CompletedProcess(["ldconfig", "-p"], 0, b"libgcc_s.so.1 => /usr/lib/libgcc_s-\xe9.so.1\n", b"")
+        generator = Mock()
+        generator._run.return_value = cmd
+
+        self.assertEqual(_get_ldconfig(generator), fsdecode(cmd.stdout).splitlines())
+
+    def test_get_ldconfig_handles_non_utf8_stderr(self):
+        """Ensure ldconfig error output with arbitrary bytes raises LDConfigError."""
+        cmd = CompletedProcess(["ldconfig", "-p"], 1, b"", b"fall\xf3 ldconfig\n")
+        generator = Mock()
+        generator._run.return_value = cmd
+
+        with self.assertRaises(LDConfigError) as error:
+            _get_ldconfig(generator)
+
+        self.assertIn(fsdecode(cmd.stderr).strip(), str(error.exception))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixed the crash in src/ugrd/base/core.py:354. _get_ldconfig() now decodes ldconfig stdout/stderr with os.fsdecode, which uses filesystem decoding with surrogateescape and won’t fail on bytes like 0xe9.

Added regression tests in tests/test_core.py:10 for non-UTF-8 stdout and stderr.

Before
```
  INSTALL /boot
 * Created temporary directory: /tmp/tmp.GF2qOqMfNY
 * Created microcode archive at: /var/tmp/kernel-install.staging.hzGZcz/microcode-amd
 * Cleaned up temporary directory: /tmp/tmp.GF2qOqMfNY
iucode_tool: Writing selected microcodes to: /var/tmp/kernel-install.staging.hzGZcz/microcode-intel
INFO     | Processing module: ugrd.base.base
INFO     | Processing module: ugrd.base.core
INFO     | Processing module: ugrd.fs.mounts
INFO     | Adding library path: /usr/lib64
INFO     | Setting initial binary search path: /usr/local/sbin, /usr/local/bin, /usr/bin, /opt/bin, /usr/lib/llvm/22/bin, /usr/lib/llvm/21/bin, /usr/lib/llvm/20/bin
INFO     | [ugrd.fs.mounts] Registered provided tag: mounts
INFO     | Processing module: ugrd.base.cmdline
INFO     | Processing module: ugrd.base.banner
INFO     | Processing module: ugrd.kmod.kmod
INFO     | Processing module: ugrd.kmod.standard_mask
INFO     | Processing module: ugrd.kmod.platform
INFO     | Processing module: ugrd.kmod.input
INFO     | Processing module: ugrd.fs.cpio
INFO     | Processing module: ugrd.base.checks
INFO     | [kernel_version] Setting from arguments: 6.18.26-gentoo
INFO     | [cpio_rotate] Setting from arguments: False
INFO     | [out_file] Setting from arguments: /var/tmp/kernel-install.staging.hzGZcz/initrd
INFO     | Resolved out_dir to: /var/tmp/kernel-install.staging.hzGZcz
INFO     | Loading config file: /etc/ugrd/config.toml
INFO     | Resolved out_dir to: /var/tmp/kernel-install.staging.hzGZcz
INFO     | -- | Running ugrd v2.2.0
INFO     | -- | Running build tasks
INFO     | Detected init at: /usr/bin/init
CRITICAL | An unhandled exception occurred while building:
CRITICAL | 'utf-8' codec can't decode byte 0xe9 in position 42: invalid continuation byte
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/ugrd/main.py", line 170, in main
    generator.build()
    ~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/ugrd/initramfs_generator.py", line 89, in build
    self.run_build()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/ugrd/initramfs_generator.py", line 251, in run_build
    self.run_hook(task, force_exclude=True)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/ugrd/initramfs_generator.py", line 162, in run_hook
    if function_output := self.run_func(function, *args, **kwargs):
                          ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/ugrd/initramfs_generator.py", line 110, in run_func
    if function_output := function(self):
                          ~~~~~~~~^^^^^^
  File "/usr/lib/python3.14/site-packages/zenlib/util/dict_check.py", line 63, in _unset
    return func(*args, **kwargs)
  File "/usr/lib/python3.14/site-packages/zenlib/util/dict_check.py", line 36, in _contains
    return func(*args, **kwargs)
  File "/usr/lib/python3.14/site-packages/ugrd/base/core.py", line 367, in autodetect_libgcc
    ldconfig = _get_ldconfig(self)
  File "/usr/lib/python3.14/site-packages/ugrd/base/core.py", line 356, in _get_ldconfig
    self.logger.log(5, "ldconfig -p output:\n%s" % cmd.stdout.decode())
                                                   ~~~~~~~~~~~~~~~~~^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 42: invalid continuation byte
modules:
  - ugrd.base.core
  - ugrd.fs.mounts
  - ugrd.base.cmdline
  - ugrd.base.banner
  - ugrd.kmod.standard_mask
  - ugrd.kmod.platform
  - ugrd.kmod.input
  - ugrd.kmod.kmod
  - ugrd.fs.cpio
  - ugrd.base.checks
  - ugrd.base.base
provided:
  - mounts
imports:
  config_processing:
    - <function _process_loglevel at 0x7faa5cd33110>
    - <function _process_log_file at 0x7faa5cd33270>
    - <function _process_init_target at 0x7faa5cd32fb0>
    - <function _process_build_logging at 0x7faa5cd8dd20>
    - <function _process_out_file at 0x7faa5cd8ce00>
    - <function _process_binary_search_paths_multi at 0x7faa5cd8d220>
    - <function _process_binaries_multi at 0x7faa5cd8d380>
    - <function _process_libraries_multi at 0x7faa5cd8d0c0>
    - <function _process_dependencies_multi at 0x7faa5cd8d640>
    - <function _process_opt_dependencies_multi at 0x7faa5cd8d7a0>
    - <function _process_xz_dependencies_multi at 0x7faa5cd8d900>
    - <function _process_zstd_dependencies_multi at 0x7faa5cd8dbc0>
    - <function _process_gz_dependencies_multi at 0x7faa5cd8da60>
    - <function _process_copies_multi at 0x7faa5cd8de80>
    - <function _process_symlinks_multi at 0x7faa5cd8dfe0>
    - <function _process_nodes_multi at 0x7faa5cd8e140>
    - <function _process_paths_multi at 0x7faa5cd8cf60>
    - <function _process_masks_multi at 0x7faa5cd8e2a0>
    - <function _process_hostonly at 0x7faa5cd8e400>
    - <function _process_validate at 0x7faa5cd8e560>
    - <function _process_run_dirs_multi at 0x7faa5c53ef00>
    - <function _process_mounts_multi at 0x7faa5c53c670>
    - <function _process_late_mounts_multi at 0x7faa5c53c7d0>
    - <function _process__non_namespaced_cmdline_args at 0x7faa5c5385c0>
    - <function _process_cmdline_bools_multi at 0x7faa5c538720>
    - <function _process_cmdline_strings_multi at 0x7faa5c538880>
    - <function _process_kernel_version at 0x7faa5c53ada0>
    - <function _process_kmod_init_multi at 0x7faa5c539b10>
    - <function _process_kernel_modules_multi at 0x7faa5c5399b0>
    - <function _process__kmod_auto_multi at 0x7faa5c539dd0>
  build_enum:
    - <function autodetect_init at 0x7faa5cd333d0>
    - <function get_tmpdir at 0x7faa5cd566c0>
    - <function autodetect_libgcc at 0x7faa5cd8c7d0>
    - <function autodetect_musl at 0x7faa5cd8ca90>
    - <function get_shell at 0x7faa5cd56980>
    - <function get_mounts_info at 0x7faa5c53d010>
    - <function get_virtual_block_info at 0x7faa5c53d590>
    - <function get_blkid_info at 0x7faa5c53d2d0>
    - <function get_zpool_info at 0x7faa5c53d380>
    - <function get_platform_info at 0x7faa5cd8f110>
    - <function autodetect_virtual_machine at 0x7faa5cd8f270>
    - <function autodetect_root at 0x7faa5c53e400>
    - <function autodetect_mounts at 0x7faa5c53e820>
    - <function autodetect_late_mounts at 0x7faa5c53eae0>
    - <function autodetect_init_mount at 0x7faa5c53e090>
    - <function get_kernel_version at 0x7faa5c53b060>
    - <function get_module_aliases at 0x7faa5c53a140>
    - <function get_builtin_module_info at 0x7faa5c53a350>
    - <function autodetect_modules at 0x7faa5c53a820>
    - <function autodetect_regulator_drivers at 0x7faa5cd8f3d0>
    - <function autodetect_platform_bus_drivers at 0x7faa5cd8f480>
    - <function autodetect_input at 0x7faa5c524bf0>
  build_tasks:
    - <function set_shebang at 0x7faa5cd338a0>
    - <function export_switch_root_target at 0x7faa5cd33ab0>
    - <function export_mount_info at 0x7faa5c53fc10>
  build_final:
    - <function set_init_final_order at 0x7faa5cd33950>
    - <function regen_ld_so_cache at 0x7faa5cd8cd50>
    - <function generate_fstab at 0x7faa5c53cd50>
    - <function regen_kmod_metadata at 0x7faa5c53b5e0>
  init_pre:
    - <function set_loglevel at 0x7faa5cd33d70>
    - <function mount_base at 0x7faa5c53eda0>
    - <function make_run_dirs at 0x7faa5c53f1c0>
    - <function export_exports at 0x7faa5c538e00>
    - <function parse_cmdline at 0x7faa5c538ca0>
    - <function print_banner at 0x7faa5c539010>
    - <function check_kver at 0x7faa5c5245c0>
    - <function load_modules at 0x7faa5c5247d0>
  init_final:
    - <function do_switch_root at 0x7faa5cd541a0>
    - <function umount_fstab at 0x7faa5c53ceb0>
  functions:
    - <function check_var at 0x7faa5cd54880>
    - <function setvar at 0x7faa5cd545c0>
    - <function readvar at 0x7faa5cd54720>
    - <function wait_for_space at 0x7faa5cd549e0>
    - <function prompt_user at 0x7faa5cd54b40>
    - <function retry at 0x7faa5cd54ca0>
    - <function klog at 0x7faa5cd54e00>
    - <function rd_log at 0x7faa5cd54f60>
    - <function edebug at 0x7faa5cd550c0>
    - <function einfo at 0x7faa5cd55220>
    - <function ewarn at 0x7faa5cd55380>
    - <function eerror at 0x7faa5cd554e0>
    - <function rd_fail at 0x7faa5cd54460>
    - <function rd_restart at 0x7faa5cd54300>
    - <function _find_init at 0x7faa5cd33c10>
    - <function mount_default_root at 0x7faa5c53f950>
    - <function parse_cmdline_bool at 0x7faa5c5389e0>
    - <function parse_cmdline_str at 0x7faa5c538b40>
  checks:
    - <function check_init_target at 0x7faa5cd32cf0>
    - <function check_switch_root_last at 0x7faa5cd540f0>
    - <function check_mounts at 0x7faa5c53f8a0>
    - <function check_proc_cmdline at 0x7faa5c538eb0>
    - <function check_cpio_deps at 0x7faa5c524e00>
    - <function check_cpio_funcs at 0x7faa5c525010>
    - <function check_in_cpio at 0x7faa5c5250c0>
    - <function check_init_order at 0x7faa5c525dd0>
    - <function check_included_funcs at 0x7faa5c525900>
    - <function check_in_file at 0x7faa5c525a60>
    - <function check_included_or_mounted at 0x7faa5c525f30>
  build_pre:
    - <function clean_build_dir at 0x7faa5cd56c40>
    - <function add_kmod_masks at 0x7faa5c524930>
    - <function get_archive_name at 0x7faa5c525640>
  build_deploy:
    - <function generate_structure at 0x7faa5cd56cf0>
    - <function handle_usr_symlinks at 0x7faa5cd57690>
    - <function get_conditional_dependencies at 0x7faa5cd56e50>
    - <function deploy_dependencies at 0x7faa5cd57740>
    - <function deploy_xz_dependencies at 0x7faa5cd57b60>
    - <function deploy_zstd_dependencies at 0x7faa5cd57d70>
    - <function deploy_gz_dependencies at 0x7faa5cd8c040>
    - <function deploy_copies at 0x7faa5cd8c0f0>
    - <function deploy_symlinks at 0x7faa5cd8c250>
    - <function deploy_nodes at 0x7faa5cd8c3b0>
  init_main:
    - <function mount_fstab at 0x7faa5c53f480>
  init_mount:
    - <function mount_root at 0x7faa5c53fab0>
    - <function mount_late at 0x7faa5c53f3d0>
  build_late:
    - <function process_modules at 0x7faa5c5243b0>
    - <function process_ignored_modules at 0x7faa5c53bed0>
    - <function process_module_metadata at 0x7faa5c53b320>
    - <function add_kmod_deps at 0x7faa5c53bc10>
  pack:
    - <function make_cpio at 0x7faa5c5256f0>
import_order:
  before:
    get_platform_info:
      - autodetect_virtual_machine
    autodetect_virtual_machine:
      - autodetect_root
  after:
    mount_late:
      - mount_root
    make_run_dirs:
      - mount_base
    export_exports:
      - make_run_dirs
    parse_cmdline:
      - export_exports
    autodetect_input:
      - get_kernel_version
    set_loglevel:
      - parse_cmdline
validated: False
custom_parameters:
  hostonly: <class 'bool'>
  validate: <class 'bool'>
  timeout: <class 'int'>
  _custom_init_file: <class 'str'>
  tmpdir: <class 'pathlib.Path'>
  build_dir: <class 'pathlib.Path'>
  random_build_dir: <class 'bool'>
  build_logging: <class 'bool'>
  _build_log_level: <class 'int'>
  symlinks: <class 'dict'>
  merge_usr: <class 'bool'>
  dependencies: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  conditional_dependencies: <class 'dict'>
  opt_dependencies: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  xz_dependencies: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  zstd_dependencies: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  gz_dependencies: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  library_paths: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  find_libgcc: <class 'bool'>
  musl_libc: <class 'bool'>
  libraries: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  binaries: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  binary_search_paths: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  copies: <class 'dict'>
  nodes: <class 'dict'>
  paths: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  masks: <class 'dict'>
  make_nodes: <class 'bool'>
  out_dir: <class 'pathlib.Path'>
  out_file: <class 'str'>
  old_count: <class 'int'>
  clean: <class 'bool'>
  shell: <class 'str'>
  mounts: <class 'dict'>
  mount_devpts: <class 'bool'>
  mount_shm: <class 'bool'>
  run_dirs: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  late_mounts: <class 'dict'>
  auto_mounts: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  auto_late_mounts: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  mount_timeout: <class 'float'>
  mount_retries: <class 'int'>
  mount_cmd: <class 'str'>
  autodetect_root: <class 'bool'>
  autodetect_dm: <class 'bool'>
  autodetect_luks: <class 'bool'>
  autodetect_lvm: <class 'bool'>
  autodetect_raid: <class 'bool'>
  autodetect_init_mount: <class 'bool'>
  no_fsck: <class 'bool'>
  _mounts: <class 'dict'>
  _vblk_info: <class 'dict'>
  _blkid_info: <class 'dict'>
  _zpool_info: <class 'dict'>
  _non_namespaced_cmdline_args: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  exports: <class 'dict'>
  cmdline_bools: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  cmdline_strings: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  banner: <class 'str'>
  kmod_ignore_video: <class 'bool'>
  kmod_ignore_sound: <class 'bool'>
  kmod_ignore_network: <class 'bool'>
  _dmi_product_name: <class 'str'>
  _dmi_system_vendor: <class 'str'>
  virtual_machine: <class 'bool'>
  kmod_autodetect_platform_bus_drivers: <class 'bool'>
  kmod_autodetect_input: <class 'bool'>
  keyboard_key_threshold: <class 'int'>
  _kmod_removed: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  _kmod_modinfo: <class 'dict'>
  _kmod_auto: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  _kmod_dir: <class 'pathlib.Path'>
  _kernel_config_file: <class 'pathlib.Path'>
  kernel_version: <class 'str'>
  kmod_ignore: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  kmod_pull_firmware: <class 'bool'>
  kmod_decompress_firmware: <class 'bool'>
  kmod_ignore_softdeps: <class 'bool'>
  kmod_autodetect_lsmod: <class 'bool'>
  kmod_autodetect_lspci: <class 'bool'>
  kernel_modules: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  kmod_init: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  kmod_init_optional: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  no_kmod: <class 'bool'>
  cpio_rotate: <class 'bool'>
  cpio_compression: <class 'str'>
  cpio_deduplicate: <class 'bool'>
  _cpio_archive: <class 'pycpio.pycpio.PyCPIO'>
  check_cpio: <class 'bool'>
  check_in_cpio: <class 'dict'>
  check_included_funcs: <class 'bool'>
  check_in_file: <class 'dict'>
  check_included_or_mounted: <class 'zenlib.types.nodupflatlist.NoDupFlatList'>
  switch_root_target: <class 'pathlib.Path'>
  init_target: <class 'pathlib.Path'>
  autodetect_init: <class 'bool'>
  loglevel: <class 'int'>
  log_file: <class 'pathlib.Path'>
  shebang: <class 'str'>
  shebang_args: <class 'str'>
custom_processing:
  _process_loglevel: <function _process_loglevel at 0x7faa5cd33110>
  _process_log_file: <function _process_log_file at 0x7faa5cd33270>
  _process_init_target: <function _process_init_target at 0x7faa5cd32fb0>
  _process_build_logging: <function _process_build_logging at 0x7faa5cd8dd20>
  _process_out_file: <function _process_out_file at 0x7faa5cd8ce00>
  _process_binary_search_paths_multi: <function _process_binary_search_paths_multi at 0x7faa5cd8d220>
  _process_binaries_multi: <function _process_binaries_multi at 0x7faa5cd8d380>
  _process_libraries_multi: <function _process_libraries_multi at 0x7faa5cd8d0c0>
  _process_dependencies_multi: <function _process_dependencies_multi at 0x7faa5cd8d640>
  _process_opt_dependencies_multi: <function _process_opt_dependencies_multi at 0x7faa5cd8d7a0>
  _process_xz_dependencies_multi: <function _process_xz_dependencies_multi at 0x7faa5cd8d900>
  _process_zstd_dependencies_multi: <function _process_zstd_dependencies_multi at 0x7faa5cd8dbc0>
  _process_gz_dependencies_multi: <function _process_gz_dependencies_multi at 0x7faa5cd8da60>
  _process_copies_multi: <function _process_copies_multi at 0x7faa5cd8de80>
  _process_symlinks_multi: <function _process_symlinks_multi at 0x7faa5cd8dfe0>
  _process_nodes_multi: <function _process_nodes_multi at 0x7faa5cd8e140>
  _process_paths_multi: <function _process_paths_multi at 0x7faa5cd8cf60>
  _process_masks_multi: <function _process_masks_multi at 0x7faa5cd8e2a0>
  _process_hostonly: <function _process_hostonly at 0x7faa5cd8e400>
  _process_validate: <function _process_validate at 0x7faa5cd8e560>
  _process_run_dirs_multi: <function _process_run_dirs_multi at 0x7faa5c53ef00>
  _process_mounts_multi: <function _process_mounts_multi at 0x7faa5c53c670>
  _process_late_mounts_multi: <function _process_late_mounts_multi at 0x7faa5c53c7d0>
  _process__non_namespaced_cmdline_args: <function _process__non_namespaced_cmdline_args at 0x7faa5c5385c0>
  _process_cmdline_bools_multi: <function _process_cmdline_bools_multi at 0x7faa5c538720>
  _process_cmdline_strings_multi: <function _process_cmdline_strings_multi at 0x7faa5c538880>
  _process_kernel_version: <function _process_kernel_version at 0x7faa5c53ada0>
  _process_kmod_init_multi: <function _process_kmod_init_multi at 0x7faa5c539b10>
  _process_kernel_modules_multi: <function _process_kernel_modules_multi at 0x7faa5c5399b0>
  _process__kmod_auto_multi: <function _process__kmod_auto_multi at 0x7faa5c539dd0>
_processing:
_late_args:
  - kernel_version
test_copy_config:
hostonly: True
validate: True
timeout: 15
_custom_init_file: init_main.sh
tmpdir: /tmp
build_dir: initramfs_build
random_build_dir: False
build_logging: False
_build_log_level: 10
symlinks:
  _auto_libblkid.so.1:
    source: /usr/lib64/libblkid.so.1.1.0
    target: /usr/lib64/libblkid.so.1
  _auto_libmount.so.1:
    source: /usr/lib64/libmount.so.1.1.0
    target: /usr/lib64/libmount.so.1
  _auto_libsmartcols.so.1:
    source: /usr/lib64/libsmartcols.so.1.1.0
    target: /usr/lib64/libsmartcols.so.1
  _auto_libtinfow.so.6:
    source: /usr/lib64/libtinfow.so.6.5
    target: /usr/lib64/libtinfow.so.6
  _auto_libudev.so.1:
    source: /usr/lib64/libudev.so.1.7.13
    target: /usr/lib64/libudev.so.1
  _auto_awk:
    source: /usr/bin/gawk
    target: /usr/bin/awk
  _auto_libreadline.so.8:
    source: /usr/lib64/libreadline.so.8.3
    target: /usr/lib64/libreadline.so.8
  _auto_libmpfr.so.6:
    source: /usr/lib64/libmpfr.so.6.2.2
    target: /usr/lib64/libmpfr.so.6
  _auto_libgmp.so.10:
    source: /usr/lib64/libgmp.so.10.5.0
    target: /usr/lib64/libgmp.so.10
  _auto_bc:
    source: /usr/bin/bc-reference
    target: /usr/bin/bc
  _auto_libpcre2-8.so.0:
    source: /usr/lib64/libpcre2-8.so.0.15.0
    target: /usr/lib64/libpcre2-8.so.0
  _auto_libcap.so.2:
    source: /usr/lib64/libcap.so.2.77
    target: /usr/lib64/libcap.so.2
  _auto_libacl.so.1:
    source: /usr/lib64/libacl.so.1.1.2302
    target: /usr/lib64/libacl.so.1
  _auto_libattr.so.1:
    source: /usr/lib64/libattr.so.1.1.2502
    target: /usr/lib64/libattr.so.1
merge_usr: True
dependencies:
  - /usr/bin/lsblk
  - /lib64/ld-linux-x86-64.so.2
  - /usr/lib64/libblkid.so.1.1.0
  - /usr/lib64/libmount.so.1.1.0
  - /usr/lib64/libsmartcols.so.1.1.0
  - /usr/lib64/libtinfow.so.6.5
  - /usr/lib64/libudev.so.1.7.13
  - /usr/lib64/libc.so.6
  - /usr/bin/blkid
  - /usr/bin/mount
  - /usr/bin/umount
  - /usr/bin/mkdir
  - /usr/bin/gawk
  - /usr/lib64/libreadline.so.8.3
  - /usr/lib64/libmpfr.so.6.2.2
  - /usr/lib64/libgmp.so.10.5.0
  - /usr/lib64/libm.so.6
  - /usr/bin/bc-reference
  - /usr/bin/dd
  - /usr/bin/grep
  - /usr/lib64/libpcre2-8.so.0.15.0
  - /usr/bin/ls
  - /usr/lib64/libcap.so.2.77
  - /usr/bin/cp
  - /usr/lib64/libacl.so.1.1.2302
  - /usr/lib64/libattr.so.1.1.2502
  - /usr/bin/cat
  - /usr/bin/setsid
  - /usr/bin/stty
  - /usr/bin/switch_root
  - /usr/bin/rm
conditional_dependencies:
opt_dependencies:
xz_dependencies:
zstd_dependencies:
gz_dependencies:
library_paths:
  - /lib64
  - /lib
  - /usr/lib64
find_libgcc: True
musl_libc: False
libraries:
binaries:
  - lsblk
  - blkid
  - mount
  - umount
  - mkdir
  - awk
  - bc
  - dd
  - grep
  - ls
  - cp
  - cat
  - setsid
  - stty
  - switch_root
  - rm
binary_search_paths:
  - /usr/local/sbin
  - /usr/local/bin
  - /usr/bin
  - /opt/bin
  - /usr/lib/llvm/22/bin
  - /usr/lib/llvm/21/bin
  - /usr/lib/llvm/20/bin
copies:
nodes:
  console:
    mode: 420
    major: 5
    minor: 1
    path: dev/console
paths:
  - target_rootfs
  - proc
  - sys
  - dev
  - dev/pts
  - dev/shm
  - run
  - etc
  - root
  - tmp
masks:
make_nodes: False
out_dir: /var/tmp/kernel-install.staging.hzGZcz
out_file: initrd
old_count: 1
clean: True
shell: 
mounts:
  root:
    options:
      + ro
    destination: /target_rootfs
    base_mount: False
  proc:
    type: proc
    path: proc
    options:
      + nosuid
      + nodev
      + noexec
    base_mount: True
    destination: /proc
  sys:
    type: sysfs
    path: sysfs
    options:
      + nosuid
      + nodev
      + noexec
    base_mount: True
    destination: /sys
  dev:
    type: devtmpfs
    path: devtmpfs
    options:
      + nosuid
      + mode=0755
    base_mount: True
    destination: /dev
  devpts:
    type: devpts
    path: devpts
    destination: /dev/pts
    options:
      + noexec
      + noauto
      + rw
      + nosuid
      + mode=620
      + gid=5
    base_mount: True
  shm:
    type: tmpfs
    path: shm
    destination: /dev/shm
    options:
      + nosuid
      + nodev
      + noexec
    base_mount: True
  run:
    type: tmpfs
    path: tmpfs
    options:
      + nosuid
      + nodev
      + mode=0755
      + noexec
    base_mount: True
    destination: /run
mount_devpts: False
mount_shm: True
run_dirs:
  - /run/ugrd
late_mounts:
auto_mounts:
auto_late_mounts:
mount_timeout: 1.0
mount_retries: 0
mount_cmd: 
autodetect_root: True
autodetect_dm: True
autodetect_luks: True
autodetect_lvm: True
autodetect_raid: True
autodetect_init_mount: True
no_fsck: False
_mounts:
_vblk_info:
_blkid_info:
_zpool_info:
_non_namespaced_cmdline_args:
  - init
  - resume
  - root
  - rootdelay
  - rootflags
  - rootfstype
  - quiet
  - loglevel
exports:
  loglevel: 5
  init: /usr/bin/init
cmdline_bools:
  - ugrd_no_fsck
  - quiet
  - ugrd_debug
  - ugrd_recovery
cmdline_strings:
  - root
  - rootfstype
  - rootflags
  - ugrd_mount_timeout
  - init
  - loglevel
  - ugrd_log_file
banner: einfo "UGRD v$(readvar VERSION)"
kmod_ignore_video: True
kmod_ignore_sound: True
kmod_ignore_network: True
_dmi_product_name: 
_dmi_system_vendor: 
virtual_machine: False
kmod_autodetect_platform_bus_drivers: False
kmod_autodetect_input: True
keyboard_key_threshold: 25
_kmod_removed:
_kmod_modinfo:
_kmod_auto:
_kmod_dir: /lib/modules/6.18.26-gentoo
_kernel_config_file: .
kernel_version: 6.18.26-gentoo
kmod_ignore:
  - kvm
  - kvm_amd
  - kvm_intel
  - reg_dummy
  - ch341
  - cp210x
  - joydev
  - binfmt_misc
  - xpad
  - coretemp
  - x86_pkg_temp_thermal
  - k10temp
  - iTCO_wdt
  - iTCO_vendor_support
  - sp5100_tco
  - intel_qat
  - intel_powerclamp
  - intel_cstate
  - rapl
  - intel_rapl_common
  - intel_rapl_msr
  - intel_pmc_bxt
  - i2c_piix4
  - spi_intel_pci
  - i2c_ismt
  - i2c_i801
kmod_pull_firmware: True
kmod_decompress_firmware: True
kmod_ignore_softdeps: False
kmod_autodetect_lsmod: False
kmod_autodetect_lspci: True
kernel_modules:
kmod_init:
kmod_init_optional:
no_kmod: False
cpio_rotate: False
cpio_compression: xz
cpio_deduplicate: True
_cpio_archive: 
check_cpio: True
check_in_cpio:
check_included_funcs: True
check_in_file:
check_included_or_mounted:
switch_root_target: .
init_target: /usr/bin/init
autodetect_init: True
loglevel: 5
log_file: .
shebang: 
shebang_args: -l

/usr/lib/kernel/install.d/52-ugrd.install failed with exit status 1.
make[1]: *** [arch/x86/Makefile:528: install] Error 1
make: *** [Makefile:248: __sub-make] Error 2
```


After
```
  INSTALL /boot
 * Created temporary directory: /tmp/tmp.WYc6IMb71c
 * Created microcode archive at: /var/tmp/kernel-install.staging.zndk7M/microcode-amd
 * Cleaned up temporary directory: /tmp/tmp.WYc6IMb71c
iucode_tool: Writing selected microcodes to: /var/tmp/kernel-install.staging.zndk7M/microcode-intel
INFO     | Processing module: ugrd.base.base
INFO     | Processing module: ugrd.base.core
INFO     | Processing module: ugrd.fs.mounts
INFO     | Adding library path: /usr/lib64
INFO     | Setting initial binary search path: /usr/local/sbin, /usr/local/bin, /usr/bin, /opt/bin, /usr/lib/llvm/22/bin, /usr/lib/llvm/21/bin, /usr/lib/llvm/20/bin
INFO     | [ugrd.fs.mounts] Registered provided tag: mounts
INFO     | Processing module: ugrd.base.cmdline
INFO     | Processing module: ugrd.base.banner
INFO     | Processing module: ugrd.kmod.kmod
INFO     | Processing module: ugrd.kmod.standard_mask
INFO     | Processing module: ugrd.kmod.platform
INFO     | Processing module: ugrd.kmod.input
INFO     | Processing module: ugrd.fs.cpio
INFO     | Processing module: ugrd.base.checks
INFO     | [kernel_version] Setting from arguments: 6.18.26-gentoo
INFO     | [cpio_rotate] Setting from arguments: False
INFO     | [out_file] Setting from arguments: /var/tmp/kernel-install.staging.zndk7M/initrd
INFO     | Resolved out_dir to: /var/tmp/kernel-install.staging.zndk7M
INFO     | Loading config file: /etc/ugrd/config.toml
INFO     | Resolved out_dir to: /var/tmp/kernel-install.staging.zndk7M
INFO     | -- | Running ugrd v2.2.0
INFO     | -- | Running build tasks
INFO     | Detected init at: /usr/bin/init
INFO     | Source path for libgcc_s: /usr/lib/gcc/x86_64-pc-linux-gnu/15/libgcc_s.so.1
INFO     | Using default shell: /bin/sh
WARNING  | No device mapper name found for: md127
WARNING  | No device mapper name found for: md125
WARNING  | No device mapper name found for: md126
WARNING  | No device mapper name found for: md124
INFO     | Found virtual block devices: dm-1, dm-10, md127, dm-8, md125, dm-6, dm-15, dm-4, dm-13, dm-2, dm-11, dm-0, dm-9, md126, dm-7, dm-16, md124, dm-5, dm-14, dm-3, dm-12
INFO     | Resolved device: /dev/dm-3 -> /dev/mapper/sarin_raid1-boot
INFO     | [/dev/mapper/sarin_raid1-boot] Auto-enabling kernel modules for device: dm_mod
INFO     | [/dev/mapper/sarin_raid1-boot] Autodetected mount type from device: ext4
INFO     | [root] Autodetected mount source: uuid=ec821fed-f16c-456e-a4df-3572568458df
INFO     | [/] Detected virtual block device: /dev/mapper/sarin_raid1-boot
INFO     | [/dev/md125] Auto-enabling kernel modules for device: md_mod
INFO     | Autodetected LVM mount, enabling the lvm module.
INFO     | Processing module: ugrd.fs.lvm
INFO     | [sarin_raid1-boot] LVM volume contianer uuid: qxAEp4-rNtg-XWEG-9pvO-GKfE-Mc2W-Hw0Dyf
INFO     | [/] Detected virtual block device: /dev/md125
INFO     | [/dev/nvme1n1p2] Auto-enabling kernel modules for device: nvme
INFO     | Autodetected MDRAID mount, enabling the mdraid module.
INFO     | Processing module: ugrd.fs.mdraid
INFO     | [md125] MDRAID level: raid1
INFO     | [sarin_raid1-boot] Autodetected device mapper container: md125
INFO     | [mounts] Updating mount: root
INFO     | Auto-enabling module: ext4
INFO     | Processing module: ugrd.fs.ext4
WARNING  | [get_kernel_version] Kernel version is already set, skipping.
INFO     | Autodetected kernel modules: dm_mod, md_mod, nvme, raid1, pcieportdrv, ohci_pci, ahci, pci_stub, iwlwifi, igb, uhci_hcd, ehci_pci, snd_hda_intel, amdgpu, r8169, xhci_pci, ccp
WARNING  | [/sys/class/regulator] Regulator path does not exist, skipping detection.
WARNING  | Unable to detect a keyboard with keyboard_key_threshold is set to: 25
WARNING  | Cleaning build directory: /tmp/initramfs_build
INFO     | Processing module: ugrd.kmod.novideo
INFO     | Processing module: ugrd.kmod.nosound
INFO     | Processing module: ugrd.kmod.nonetwork
INFO     | Setting shebang to: #!/bin/sh -l
WARNING  | [pcieportdrv] Failed to process autodetected kernel module dependencies: [pcieportdrv] Modinfo returned no output and the alias name could no be resolved.
INFO     | [deploy_nodes] Skipping real device node creation with mknod, as make_nodes is not specified.
INFO     | Regenerating ld.so.cache
INFO     | Wrote file: /tmp/initramfs_build/etc/ld.so.conf
INFO     | Regenerating kernel module metadata files.
INFO     | -- | Generating init functions
INFO     | Init kernel modules: ccp
INFO     | Included kernel modules: i2c_algo_bit
WARNING  | Ignored kernel modules: i2c_piix4, k10temp, amdgpu, snd_hda_intel, iwlwifi, r8169, igb, pcieportdrv
INFO     | No initramfs fstab found, skipping mount_fstab. If non-root storage devices are not needed at boot, this is fine.
INFO     | Wrote file: /tmp/initramfs_build/etc/profile
INFO     | Included functions: check_var, setvar, readvar, wait_for_space, prompt_user, retry, klog, rd_log, edebug, einfo, ewarn, eerror, rd_fail, rd_restart, _find_init, mount_default_root, parse_cmdline_bool, parse_cmdline_str, mount_base, export_exports, parse_cmdline, print_banner, check_kver, load_modules, md_init, init_lvm, mount_root, ext4_fsck, do_switch_root
INFO     | Wrote file: /tmp/initramfs_build/init
INFO     | -- | Packing build
INFO     | [XZ] Compressing the CPIO data, original size: 19.67 MiB
INFO     | Wrote 6.44 MiB to: /var/tmp/kernel-install.staging.zndk7M/initrd
INFO     | -- | Running checks
INFO     | Resolved device: /dev/dm-3 -> /dev/mapper/sarin_raid1-boot
Generando un fichero de configuración de grub...
Encontrada imagen de linux: /boot/kernel-6.18.26-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.18.26-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.18.18-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.18.18-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.12.58-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.12.58-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.12.41-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.12.41-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.12.31-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.12.31-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.12.21-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.12.21-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.6.38-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.6.38-gentoo.img
Encontrada imagen de linux: /boot/kernel-6.6.30-gentoo
Encontrada imagen de memoria inicial: /boot/intel-uc.img /boot/amd-uc.img /boot/initramfs-6.6.30-gentoo.img
Aviso: os-prober will not be executed to detect other bootable partitions.
Systems on them will not be added to the GRUB boot configuration.
Check GRUB_DISABLE_OS_PROBER documentation entry.
Adding boot menu entry for UEFI Firmware Settings ...
Found memtest image: /boot/memtest86plus/memtest64.bios
Found memtest image: /boot/memtest86plus/memtest.efi64
hecho
```
