### PR TITLE
net: handle missing metric field in default routes

### DIFF
--- a/src/ugrd/net/net.py
+++ b/src/ugrd/net/net.py
@@ -55,7 +55,7 @@ def autodetect_net_device(self):
     gateways = {}
     for route in routes:
         if route["dst"] == "default":
-            gateways[route["metric"]] = route
+            gateways[route("metric", 0)] = route
 
     if not gateways:
         raise AutodetectError("No default route found")


### PR DESCRIPTION
ip -j r does not always include a "metric" key for default routes. Use .get("metric", 0) so routes without an explicit metric are treated as highest priority (0) rather than crashing with KeyError.

This is a potential fix for #437